### PR TITLE
Refactor CLI to use Shell component with real progress reporting

### DIFF
--- a/src/components/AnalysisProgress.tsx
+++ b/src/components/AnalysisProgress.tsx
@@ -1,0 +1,52 @@
+import React, { useState, useEffect } from 'react';
+import { Text, Box } from 'ink';
+import { performAnalysis } from '../commands/analyze';
+
+interface AnalysisProgressProps {
+  onComplete: (result: any) => void;
+  onError: (error: Error) => void;
+}
+
+export const AnalysisProgress: React.FC<AnalysisProgressProps> = ({ onComplete, onError }) => {
+  const [currentStep, setCurrentStep] = useState('Initializing workspace analysis...');
+  const [isComplete, setIsComplete] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const runAnalysis = async () => {
+      try {
+        const result = await performAnalysis((step) => {
+          setCurrentStep(step);
+        });
+        
+        setIsComplete(true);
+        setCurrentStep('Analysis complete!');
+        onComplete(result);
+        
+      } catch (err) {
+        const errorMessage = err instanceof Error ? err.message : 'Unknown error';
+        setError(errorMessage);
+        setCurrentStep('Analysis failed');
+        onError(err instanceof Error ? err : new Error(errorMessage));
+      }
+    };
+
+    runAnalysis();
+  }, [onComplete, onError]);
+
+  if (error) {
+    return (
+      <Box>
+        <Text color="red">❌ {currentStep}: {error}</Text>
+      </Box>
+    );
+  }
+
+  return (
+    <Box>
+      <Text color={isComplete ? 'green' : 'blue'}>
+        {isComplete ? '✅' : '⏳'} {currentStep}
+      </Text>
+    </Box>
+  );
+};

--- a/src/components/Shell.tsx
+++ b/src/components/Shell.tsx
@@ -1,0 +1,105 @@
+import React, { useState, useEffect } from 'react';
+import { Box, Text } from 'ink';
+import { AnalysisProgress } from './AnalysisProgress';
+import { performAnalysis } from '../commands/analyze';
+
+interface ShellProps {
+  command: 'analyze';
+  options: {
+    progress?: boolean;
+  };
+}
+
+export const Shell: React.FC<ShellProps> = ({ command, options }) => {
+  const [result, setResult] = useState<any>(null);
+  const [error, setError] = useState<Error | null>(null);
+  const [isComplete, setIsComplete] = useState(false);
+  const [simpleStep, setSimpleStep] = useState<string>('');
+
+  useEffect(() => {
+    if (command === 'analyze' && options.progress === false && !isComplete && !error) {
+      const runSimpleAnalysis = async () => {
+        try {
+          const analysisResult = await performAnalysis((step) => {
+            setSimpleStep(step);
+          });
+          setResult(analysisResult);
+          setIsComplete(true);
+        } catch (err) {
+          setError(err instanceof Error ? err : new Error(String(err)));
+        }
+      };
+      runSimpleAnalysis();
+    }
+  }, [command, options.progress, isComplete, error]);
+
+  if (command === 'analyze') {
+    if (options.progress === false) {
+      if (error) {
+        return (
+          <Box flexDirection="column">
+            <Text color="red">❌ Error: {error.message}</Text>
+          </Box>
+        );
+      }
+
+      if (isComplete && result) {
+        return (
+          <Box flexDirection="column">
+            <Text color="green">✅ Analysis complete!</Text>
+            <Text>{JSON.stringify(result.analysis, null, 2)}</Text>
+            {result.metadata && (
+              <>
+                <Text color="yellow">💰 Cost: ${result.metadata.cost_usd.toFixed(4)}</Text>
+                <Text color="cyan">🔄 Turns: {result.metadata.turns}</Text>
+              </>
+            )}
+          </Box>
+        );
+      }
+
+      return (
+        <Box flexDirection="column">
+          <Text color="blue">🔍 {simpleStep || 'Analyzing workspace...'}</Text>
+        </Box>
+      );
+    }
+
+    if (error) {
+      return (
+        <Box flexDirection="column">
+          <Text color="red">❌ Error: {error.message}</Text>
+        </Box>
+      );
+    }
+
+    if (isComplete && result) {
+      return (
+        <Box flexDirection="column">
+          <Text color="green">✅ Analysis complete!</Text>
+          <Text>{JSON.stringify(result.analysis, null, 2)}</Text>
+          {result.metadata && (
+            <>
+              <Text color="yellow">💰 Cost: ${result.metadata.cost_usd.toFixed(4)}</Text>
+              <Text color="cyan">🔄 Turns: {result.metadata.turns}</Text>
+            </>
+          )}
+        </Box>
+      );
+    }
+
+    return (
+      <AnalysisProgress
+        onComplete={(result) => {
+          setResult(result);
+          setIsComplete(true);
+        }}
+        onError={(error) => {
+          setError(error);
+        }}
+      />
+    );
+  }
+
+  return <Text>Unknown command: {command}</Text>;
+};

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,5 +1,7 @@
 import { Command } from 'commander';
-import { performAnalysis } from './commands/analyze';
+import { render } from 'ink';
+import React from 'react';
+import { Shell } from './components/Shell';
 
 const program = new Command();
 
@@ -12,24 +14,16 @@ program
 program
   .command('analyze')
   .description('Analyze your workspace structure and provide insights')
-  .action(async () => {
-    try {
-      console.log('🔍 Analyzing workspace...\n');
-      
-      const result = await performAnalysis();
-      
-      console.log('\n✅ Analysis complete!');
-      console.log(JSON.stringify(result, null, 2));
-      
-      if (result.metadata) {
-        console.log(`\n💰 Cost: $${result.metadata.cost_usd.toFixed(4)}`);
-        console.log(`🔄 Turns: ${result.metadata.turns}`);
-      }
-      
-    } catch (error) {
-      console.error('\n❌ Error:', error instanceof Error ? error.message : String(error));
-      process.exit(1);
-    }
+  .option('--no-progress', 'Disable progress UI')
+  .action(async (options) => {
+    render(
+      React.createElement(Shell, {
+        command: 'analyze',
+        options: {
+          progress: options.progress
+        }
+      })
+    );
   });
 
 program.parse();


### PR DESCRIPTION
## Summary
• Created Shell.tsx component to handle all CLI output using ink instead of console.log
• Updated performAnalysis to accept progress callback for real-time progress updates
• Added --no-progress option for simple text mode without progress UI
• Removed artificial timeouts and unused getProjectIdentifier call for cleaner code

## Test plan
- [x] Test `chorenzo analyze` (progress mode) - shows real-time progress steps
- [x] Test `chorenzo analyze --no-progress` (simple mode) - shows basic progress text
- [x] Verify both modes display analysis results and metadata correctly
- [x] Confirm no console.log calls remain in main.ts
- [x] Build and typecheck pass successfully