### PR TITLE
Implement chorenzo init command

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,13 +12,15 @@
         "@anthropic-ai/claude-code": "^1.0.38",
         "commander": "^14.0.0",
         "ink": "^6.0.1",
-        "react": "^19.1.0"
+        "react": "^19.1.0",
+        "simple-git": "^3.28.0",
+        "yaml": "^2.8.0"
       },
       "bin": {
         "chorenzo": "dist/main.js"
       },
       "devDependencies": {
-        "@types/node": "^24.0.8",
+        "@types/node": "^24.0.10",
         "@types/react": "^19.1.8",
         "esbuild-plugin-copy": "^2.1.1",
         "tsup": "^8.5.0",
@@ -794,6 +796,21 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@kwsites/file-exists": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@kwsites/file-exists/-/file-exists-1.1.1.tgz",
+      "integrity": "sha512-m9/5YGR18lIwxSFDwfE3oA7bWuq9kdau6ugN4H2rJeyhFQZcG9AgSHkQtSD15a8WvTgfz9aikZMrKPHvbpqFiw==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.1.1"
+      }
+    },
+    "node_modules/@kwsites/promise-deferred": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@kwsites/promise-deferred/-/promise-deferred-1.1.1.tgz",
+      "integrity": "sha512-GaHYm+c0O9MjZRu0ongGBRbinu8gVAMd2UZjji6jVmqKtZluZnptXGWhz1E8j8D2HJ3f/yMxKAUC0b+57wncIw==",
+      "license": "MIT"
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -1131,9 +1148,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "24.0.8",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.0.8.tgz",
-      "integrity": "sha512-WytNrFSgWO/esSH9NbpWUfTMGQwCGIKfCmNlmFDNiI5gGhgMmEA+V1AEvKLeBNvvtBnailJtkrEa2OIISwrVAA==",
+      "version": "24.0.10",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.0.10.tgz",
+      "integrity": "sha512-ENHwaH+JIRTDIEEbDK6QSQntAYGtbvdDXnMXnZaZ6k13Du1dPMmprkEHIL7ok2Wl2aZevetwTAb5S+7yIF+enA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1507,7 +1524,6 @@
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
       "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -2293,7 +2309,6 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/mz": {
@@ -2711,6 +2726,21 @@
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
       "license": "ISC"
+    },
+    "node_modules/simple-git": {
+      "version": "3.28.0",
+      "resolved": "https://registry.npmjs.org/simple-git/-/simple-git-3.28.0.tgz",
+      "integrity": "sha512-Rs/vQRwsn1ILH1oBUy8NucJlXmnnLeLCfcvbSehkPzbv3wwoFWIdtfd6Ndo6ZPhlPsCZ60CPI4rxurnwAa+a2w==",
+      "license": "MIT",
+      "dependencies": {
+        "@kwsites/file-exists": "^1.1.1",
+        "@kwsites/promise-deferred": "^1.1.1",
+        "debug": "^4.4.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/steveukx/git-js?sponsor=1"
+      }
     },
     "node_modules/slash": {
       "version": "3.0.0",
@@ -3322,6 +3352,18 @@
         "utf-8-validate": {
           "optional": true
         }
+      }
+    },
+    "node_modules/yaml": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.0.tgz",
+      "integrity": "sha512-4lLa/EcQCB0cJkyts+FpIRx5G/llPxfP6VQU5KByHEhLxY3IJCH0f0Hy1MHI8sClTvsIb8qwRJ6R/ZdlDJ/leQ==",
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
       }
     },
     "node_modules/yoga-layout": {

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   "author": "",
   "license": "Apache-2.0",
   "devDependencies": {
-    "@types/node": "^24.0.8",
+    "@types/node": "^24.0.10",
     "@types/react": "^19.1.8",
     "esbuild-plugin-copy": "^2.1.1",
     "tsup": "^8.5.0",
@@ -44,6 +44,8 @@
     "@anthropic-ai/claude-code": "^1.0.38",
     "commander": "^14.0.0",
     "ink": "^6.0.1",
-    "react": "^19.1.0"
+    "react": "^19.1.0",
+    "simple-git": "^3.28.0",
+    "yaml": "^2.8.0"
   }
 }

--- a/src/commands/init.tsx
+++ b/src/commands/init.tsx
@@ -1,0 +1,167 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+import { checkGitAvailable, cloneRepository, GitError } from '../utils/git-operations.utils';
+import { retry } from '../utils/retry.utils';
+import { readYaml, writeYaml, YamlError } from '../utils/yaml.utils';
+
+const CHORENZO_DIR = path.join(os.homedir(), '.chorenzo');
+const CONFIG_PATH = path.join(CHORENZO_DIR, 'config.yaml');
+const STATE_PATH = path.join(CHORENZO_DIR, 'state.yaml');
+const RECIPES_DIR = path.join(CHORENZO_DIR, 'recipes');
+
+export interface InitOptions {
+  reset?: boolean;
+}
+
+export interface ConfigLibrary {
+  repo: string;
+  ref: string;
+}
+
+export interface Config {
+  libraries: {
+    [key: string]: ConfigLibrary;
+  };
+}
+
+export interface State {
+  last_checked: string;
+}
+
+export type ProgressCallback = (step: string) => void;
+
+export class InitError extends Error {
+  constructor(message: string, public readonly code: string) {
+    super(message);
+    this.name = 'InitError';
+  }
+}
+
+export async function performInit(options: InitOptions = {}, onProgress?: ProgressCallback): Promise<void> {
+  try {
+    if (options.reset) {
+      onProgress?.('Resetting workspace...');
+      await resetWorkspace();
+    }
+
+    onProgress?.('Creating directory structure...');
+    await createDirectoryStructure();
+
+    onProgress?.('Setting up configuration files...');
+    await setupConfigFiles();
+
+    onProgress?.('Reading configuration...');
+    const config = await readConfig();
+
+    onProgress?.('Cloning recipe libraries...');
+    await cloneLibraries(config, onProgress);
+
+    onProgress?.('Initialization complete!');
+  } catch (error) {
+    if (error instanceof InitError || error instanceof GitError || error instanceof YamlError) {
+      throw error;
+    }
+    throw new InitError(
+      `Init failed: ${error instanceof Error ? error.message : String(error)}`,
+      'INIT_FAILED'
+    );
+  }
+}
+
+async function resetWorkspace(): Promise<void> {
+  if (fs.existsSync(RECIPES_DIR)) {
+    fs.rmSync(RECIPES_DIR, { recursive: true, force: true });
+  }
+
+  if (fs.existsSync(CONFIG_PATH)) {
+    fs.unlinkSync(CONFIG_PATH);
+  }
+
+  if (fs.existsSync(STATE_PATH)) {
+    fs.unlinkSync(STATE_PATH);
+  }
+}
+
+async function createDirectoryStructure(): Promise<void> {
+  fs.mkdirSync(RECIPES_DIR, { recursive: true });
+}
+
+async function setupConfigFiles(): Promise<void> {
+  if (!fs.existsSync(CONFIG_PATH)) {
+    const defaultConfig: Config = {
+      libraries: {
+        core: {
+          repo: 'https://github.com/chorenzo-dev/recipes-core.git',
+          ref: 'main'
+        }
+      }
+    };
+    await writeYaml(CONFIG_PATH, defaultConfig);
+  }
+
+  if (!fs.existsSync(STATE_PATH)) {
+    const defaultState: State = {
+      last_checked: '1970-01-01T00:00:00Z'
+    };
+    await writeYaml(STATE_PATH, defaultState);
+  }
+}
+
+async function readConfig(): Promise<Config> {
+  try {
+    const config = await readYaml<Config>(CONFIG_PATH);
+    
+    if (!config.libraries || typeof config.libraries !== 'object') {
+      throw new InitError('Invalid config.yaml: missing or invalid libraries section', 'INVALID_CONFIG');
+    }
+
+    return config;
+  } catch (error) {
+    if (error instanceof InitError) {
+      throw error;
+    }
+    if (error instanceof YamlError) {
+      throw new InitError(
+        `Failed to read config.yaml: ${error.message}`,
+        'CONFIG_READ_ERROR'
+      );
+    }
+    throw new InitError(
+      `Failed to read config.yaml: ${error instanceof Error ? error.message : String(error)}`,
+      'CONFIG_READ_ERROR'
+    );
+  }
+}
+
+async function cloneLibraries(config: Config, onProgress?: ProgressCallback): Promise<void> {
+  await checkGitAvailable();
+
+  for (const [libName, libConfig] of Object.entries(config.libraries)) {
+    const libPath = path.join(RECIPES_DIR, libName);
+    
+    if (fs.existsSync(libPath)) {
+      onProgress?.(`Skipping ${libName} (already exists)`);
+      continue;
+    }
+
+    onProgress?.(`Cloning ${libName} from ${libConfig.repo}...`);
+    
+    try {
+      await retry(
+        () => cloneRepository(libConfig.repo, libPath, libConfig.ref),
+        {
+          maxAttempts: 2,
+          onRetry: (attempt) => {
+            onProgress?.(`Retrying clone of ${libName} (attempt ${attempt + 1})...`);
+          }
+        }
+      );
+      onProgress?.(`Successfully cloned ${libName}`);
+    } catch (error) {
+      onProgress?.(`Warning: Failed to clone ${libName} after retry, skipping...`);
+      console.warn(`Failed to clone library ${libName}: ${error instanceof Error ? error.message : String(error)}`);
+    }
+  }
+}
+

--- a/src/components/InitProgress.tsx
+++ b/src/components/InitProgress.tsx
@@ -1,0 +1,44 @@
+import React, { useState, useEffect } from 'react';
+import { Box, Text } from 'ink';
+import { performInit, InitError, type InitOptions } from '../commands/init';
+
+interface InitProgressProps {
+  options: InitOptions;
+  onComplete: () => void;
+  onError: (error: Error) => void;
+}
+
+export const InitProgress: React.FC<InitProgressProps> = ({ options, onComplete, onError }) => {
+  const [currentStep, setCurrentStep] = useState<string>('Starting initialization...');
+  const [isComplete, setIsComplete] = useState(false);
+
+  useEffect(() => {
+    const runInit = async () => {
+      try {
+        await performInit(options, (step: string) => {
+          setCurrentStep(step);
+        });
+        setIsComplete(true);
+        onComplete();
+      } catch (error) {
+        onError(error instanceof Error ? error : new Error(String(error)));
+      }
+    };
+
+    runInit();
+  }, [options, onComplete, onError]);
+
+  if (isComplete) {
+    return (
+      <Box flexDirection="column">
+        <Text color="green">✅ {currentStep}</Text>
+      </Box>
+    );
+  }
+
+  return (
+    <Box flexDirection="column">
+      <Text color="blue">🔧 {currentStep}</Text>
+    </Box>
+  );
+};

--- a/src/main.ts
+++ b/src/main.ts
@@ -26,4 +26,21 @@ program
     );
   });
 
+program
+  .command('init')
+  .description('Initialize chorenzo workspace with recipe libraries')
+  .option('--reset', 'Reset and reinitialize the workspace')
+  .option('--no-progress', 'Disable progress UI')
+  .action(async (options) => {
+    render(
+      React.createElement(Shell, {
+        command: 'init',
+        options: {
+          reset: options.reset,
+          progress: options.progress
+        }
+      })
+    );
+  });
+
 program.parse();

--- a/src/utils/git-operations.utils.ts
+++ b/src/utils/git-operations.utils.ts
@@ -1,0 +1,30 @@
+import { simpleGit } from 'simple-git';
+
+export class GitError extends Error {
+  constructor(message: string, public readonly code: string) {
+    super(message);
+    this.name = 'GitError';
+  }
+}
+
+export async function checkGitAvailable(): Promise<void> {
+  const git = simpleGit();
+  
+  try {
+    await git.raw(['--version']);
+  } catch (error) {
+    throw new GitError(
+      'Git is not installed or not available in PATH. Please install Git first.',
+      'GIT_NOT_FOUND'
+    );
+  }
+}
+
+export async function cloneRepository(
+  repoUrl: string,
+  targetPath: string,
+  ref: string
+): Promise<void> {
+  const git = simpleGit();
+  await git.clone(repoUrl, targetPath, ['--depth', '1', '--branch', ref]);
+}

--- a/src/utils/retry.utils.ts
+++ b/src/utils/retry.utils.ts
@@ -1,0 +1,32 @@
+export interface RetryOptions {
+  maxAttempts?: number;
+  delayMs?: number;
+  onRetry?: (attempt: number, error: Error) => void;
+}
+
+export async function retry<T>(
+  operation: () => Promise<T>,
+  options: RetryOptions = {}
+): Promise<T> {
+  const { maxAttempts = 2, delayMs = 0, onRetry } = options;
+  
+  let lastError: Error;
+  
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    try {
+      return await operation();
+    } catch (error) {
+      lastError = error instanceof Error ? error : new Error(String(error));
+      
+      if (attempt < maxAttempts) {
+        onRetry?.(attempt, lastError);
+        
+        if (delayMs > 0) {
+          await new Promise(resolve => setTimeout(resolve, delayMs));
+        }
+      }
+    }
+  }
+  
+  throw lastError!;
+}

--- a/src/utils/yaml.utils.ts
+++ b/src/utils/yaml.utils.ts
@@ -1,0 +1,37 @@
+import * as fs from 'fs';
+import { parse as yamlParse, stringify as yamlStringify } from 'yaml';
+
+export class YamlError extends Error {
+  constructor(message: string, public readonly code: string) {
+    super(message);
+    this.name = 'YamlError';
+  }
+}
+
+export async function readYaml<T>(filePath: string): Promise<T> {
+  try {
+    const fileContent = fs.readFileSync(filePath, 'utf8');
+    const data = yamlParse(fileContent) as T;
+    return data;
+  } catch (error) {
+    if (error instanceof Error && 'code' in error && error.code === 'ENOENT') {
+      throw new YamlError(`File not found: ${filePath}`, 'FILE_NOT_FOUND');
+    }
+    throw new YamlError(
+      `Failed to read YAML file: ${error instanceof Error ? error.message : String(error)}`,
+      'READ_ERROR'
+    );
+  }
+}
+
+export async function writeYaml<T>(filePath: string, data: T): Promise<void> {
+  try {
+    const yamlContent = yamlStringify(data);
+    fs.writeFileSync(filePath, yamlContent, 'utf8');
+  } catch (error) {
+    throw new YamlError(
+      `Failed to write YAML file: ${error instanceof Error ? error.message : String(error)}`,
+      'WRITE_ERROR'
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- Implement `chorenzo init` command to bootstrap the local recipe workspace
- Add automatic directory scaffolding and YAML configuration files
- Clone recipe libraries from configured repositories with retry support

## Changes
- **Init Command**: New command that creates `~/.chorenzo/` directory structure with config.yaml, state.yaml, and recipes folder
- **Git Operations**: Extract reusable git utilities for checking availability and cloning repositories
- **YAML Utilities**: Add typed YAML read/write functions for configuration management
- **Retry Mechanism**: Generic retry utility for handling transient failures
- **Progress UI**: Ink-based progress reporting for better user experience
- **Reset Option**: `--reset` flag to completely reinitialize the workspace

## Directory Structure
```
~/.chorenzo/
├── config.yaml      # User-editable recipe library configuration
├── state.yaml       # Runtime metadata (last update timestamp)
└── recipes/         # Cloned recipe libraries
    └── core/        # Default recipes-core repository
```

## Test Plan
- [x] Run `npm start -- init` to initialize workspace
- [x] Verify directory structure is created correctly
- [x] Confirm recipe libraries are cloned successfully
- [x] Test `--reset` option to reinitialize
- [x] Test with missing Git installation (error handling)
- [x] Test retry mechanism for clone failures