### PR TITLE
Fix help menu and ensure consistency

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -182,7 +182,10 @@ recipesCommand
   .option('--no-progress', 'Disable progress UI')
   .option('--debug', 'Show all progress messages in list format')
   .option('--cost', 'Show LLM cost information')
-  .option('--location <path>', 'Custom save location for the recipe')
+  .option(
+    '--location <path>',
+    'Custom save location (supports ~ for home directory)'
+  )
   .option('--category <category>', 'Recipe category')
   .option('--summary <summary>', 'Recipe summary')
   .addHelpText(
@@ -190,11 +193,6 @@ recipesCommand
     `
 Arguments:  
   name      Recipe name (optional, will prompt if not provided)
-
-Options:
-  --location <path>    Custom path to save recipe (supports ~ for home directory)
-  --category <name>    Recipe category (required in non-interactive mode)
-  --summary <text>     Recipe summary (required in non-interactive mode)
 
 Examples:
   $ chorenzo recipes generate                               # Interactive generation


### PR DESCRIPTION
## Summary
- Fixed duplicate "Options" section in `recipes generate` help menu
- Ensured all commands properly document their available flags
- Verified help menus accurately reflect the implementation in main.ts

## Changes
- Removed duplicate Options section from recipes generate help text
- Cleaned up option descriptions for clarity
- Removed "required in non-interactive mode" mentions for better UX

## Test Plan
- [x] Verified all help menus display correctly: `npx chorenzo --help`, `npx chorenzo recipes --help`, etc.
- [x] Confirmed each command's help accurately lists all available flags from main.ts
- [x] All tests pass: `npm test`
- [x] Build succeeds: `npm run build`

Fixes CHO-36