### PR TITLE
Add --ecosystem-agnostic CLI parameter to recipes generate command

### DIFF
--- a/src/Shell.tsx
+++ b/src/Shell.tsx
@@ -31,6 +31,7 @@ interface ShellProps {
     saveLocation?: string;
     category?: string;
     summary?: string;
+    ecosystemAgnostic?: boolean;
   };
 }
 
@@ -139,6 +140,7 @@ export const Shell: React.FC<ShellProps> = ({ command, options }) => {
           saveLocation: options.saveLocation,
           category: options.category,
           summary: options.summary,
+          ecosystemAgnostic: options.ecosystemAgnostic,
         }}
         onError={(error) => {
           setError(error);

--- a/src/containers/RecipesGenerateContainer.tsx
+++ b/src/containers/RecipesGenerateContainer.tsx
@@ -26,6 +26,9 @@ function buildRetryCliCommand(options: RecipesGenerateOptions): string {
   if (options.saveLocation) {
     cliCommand += ` --location "${options.saveLocation}"`;
   }
+  if (options.ecosystemAgnostic) {
+    cliCommand += ` --ecosystem-agnostic`;
+  }
   return cliCommand;
 }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -188,6 +188,10 @@ recipesCommand
   )
   .option('--category <category>', 'Recipe category')
   .option('--summary <summary>', 'Recipe summary')
+  .option(
+    '--ecosystem-agnostic',
+    'Create recipe that works across multiple ecosystems'
+  )
   .addHelpText(
     'after',
     `
@@ -199,6 +203,7 @@ Examples:
   $ chorenzo recipes generate code-formatting               # Generate with name
   $ chorenzo recipes generate linting --category tools --summary "Set up ESLint and Prettier with TypeScript support for consistent code formatting"
   $ chorenzo recipes generate testing --location ~/my-recipes --category development --summary "Configure Jest testing framework with coverage reporting and TypeScript integration"
+  $ chorenzo recipes generate docker --ecosystem-agnostic --category infrastructure --summary "Add Docker support for any project type"
 `
   )
   .action(async (name, options) => {
@@ -213,6 +218,7 @@ Examples:
           saveLocation: options.location,
           category: options.category,
           summary: options.summary,
+          ecosystemAgnostic: options.ecosystemAgnostic,
         },
       })
     );


### PR DESCRIPTION
## Summary
- Added `--ecosystem-agnostic` CLI parameter to the `recipes generate` command  
- Users can now specify ecosystem-agnostic recipes directly from the CLI without going through interactive prompts
- The backend already had full support for ecosystem-agnostic recipes from CHO-35

## Changes
- Added `--ecosystem-agnostic` option to the recipes generate command in main.ts
- Propagated the parameter through Shell component and RecipesGenerateContainer
- Updated retry CLI command builder to include the flag when present
- Added example usage in help text documentation

## Test plan
- [x] Build passes (`npm run build`)
- [x] All existing tests pass (`npm test`)
- [x] Help text shows the new parameter (`npx chorenzo recipes generate --help`)
- [ ] Manual test: Generate an ecosystem-agnostic recipe using the CLI flag
- [ ] Manual test: Verify the generated recipe has `fix.md` instead of `fixes/` directory

## Linear Issue
Closes CHO-39