### PR TITLE
Refactor recipe structure to support base fix.md with optional variant-specific additions

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ npx chorenzo recipes generate api-endpoints --magic-generate \
 - `--category <category>`: Recipe category (required for non-interactive mode)
 - `--summary <summary>`: Recipe summary (required for non-interactive mode)
 - `--ecosystem-agnostic`: Create recipe that works across multiple ecosystems (generates single fix.md file)
-- `--ecosystem-specific`: Create recipe with separate fixes for each ecosystem (generates fixes/ directory with ecosystem-specific files)
+- `--ecosystem-specific`: Create recipe with separate fixes for each ecosystem (generates fix.md base file plus variants/ directory with ecosystem-specific files)
 - `--magic-generate`: Generate recipe content using AI (uses Claude)
 - `--additional-instructions <instructions>`: Additional instructions for AI generation (requires --magic-generate)
 

--- a/docs/recipes.md
+++ b/docs/recipes.md
@@ -42,18 +42,21 @@ Intelligently apply at workspace or project level based on ecosystem and state c
 
 ## Recipe Structure
 
-Each recipe is a self-contained folder with a specific structure. Most recipes are **ecosystem-specific** and work with particular programming languages or frameworks:
+All recipes use a unified structure with a mandatory base `fix.md` file and optional variant-specific additions:
 
 ```
 recipe_id/
 ├── metadata.yaml      # Recipe configuration and dependencies
 ├── prompt.md          # Consolidated LLM instructions
-└── fixes/
-    ├── variant_a.md   # Fix instructions for variant A
-    └── variant_b.md   # Fix instructions for variant B
+├── fix.md             # REQUIRED: Base instructions for all ecosystems
+└── variants/          # OPTIONAL: Variant-specific additions
+    ├── eslint.md               # Simple variant name
+    ├── github-actions.md       # Simple variant name
+    ├── javascript_eslint.md    # Ecosystem-prefixed variant
+    └── python_ruff.md          # Ecosystem-prefixed variant
 ```
 
-**Ecosystem-agnostic recipes** work across all programming languages and use a simpler structure with `ecosystems: []` and a single `fix.md` file instead of the `fixes/` directory.
+**All recipes** must have a `fix.md` file containing base instructions. **Ecosystem-agnostic recipes** use `ecosystems: []` and typically only need the base `fix.md` file. **Ecosystem-specific recipes** can add variant files in the `variants/` directory for specialized implementations.
 
 ## File Contents
 
@@ -72,7 +75,7 @@ ecosystems: # Languages/runtimes this recipe supports
     default_variant: prettier
     variants:
       - id: prettier
-        fix_prompt: fixes/javascript_prettier.md
+        fix_prompt: variants/javascript_prettier.md
 
 provides: # Facts this recipe outputs
   - recipe_id.exists
@@ -110,27 +113,47 @@ One-sentence goal describing what this recipe accomplishes.
 
 **Important**: Investigation and fix prompts are consumed by machines, not humans. Use definitive, declarative language (e.g., "Install the package" not "You should install the package").
 
-### fixes/variant.md
+### fix.md
 
-Implementation instructions for specific ecosystems and tool variants:
+Base implementation instructions that work for all ecosystems:
 
 ```markdown
-# Setting up [Tool Name] for [Ecosystem]
+# Setting up [Recipe Name]
 
 ## Installation
 
-Concrete commands to install the tool for this specific ecosystem.
+Common installation steps that work across ecosystems.
 
 ## Configuration
 
-Example configuration with ecosystem-specific defaults.
+Base configuration that applies universally.
 
 ## Verification
 
-How to verify the tool is working correctly in this ecosystem.
+How to verify the setup is working correctly.
 ```
 
-> **Note**: Ecosystem-agnostic recipes use a single `fix.md` file with universal instructions that work across all programming languages, instead of the `fixes/` directory.
+### variants/[variant].md
+
+Optional variant-specific additions for specific tools or ecosystems:
+
+```markdown
+# [Variant Name] specific additions
+
+## Additional Installation
+
+Additional steps specific to this variant.
+
+## Variant Configuration
+
+Configuration specific to this tool or ecosystem.
+
+## Variant Verification
+
+Additional verification steps for this variant.
+```
+
+**Content Concatenation**: When applying a recipe with a variant, the system automatically concatenates `fix.md` content with the variant content: `baseContent + '\n\n' + variantContent`. This allows for shared base instructions with variant-specific additions.
 
 ## Recipe Design Principles
 
@@ -187,7 +210,7 @@ See `code_quality/code_formatting/` for a complete example implementing code for
 2. Add `metadata.yaml` with at least: id, summary, level, ecosystems, provides
 3. Write `prompt.md` with Goal, Investigation, and Expected Output sections
 4. Add fix implementation:
-   - **Most recipes**: Add variant-specific fix prompts under `fixes/` directory
+   - **Most recipes**: Add variant-specific fix prompts under `variants/` directory
    - **Universal tools only**: Use `ecosystems: []` and create a single `fix.md` file
 5. Ensure all paths in metadata.yaml match actual file locations
 6. Choose the appropriate level:

--- a/src/commands/recipes.test.ts
+++ b/src/commands/recipes.test.ts
@@ -111,7 +111,7 @@ describe('Recipes Command Integration Tests', () => {
       recipeId = 'test-recipe',
       category = 'test',
       level = 'project-only',
-      variants = [{ id: 'basic', fix_prompt: 'fixes/basic.md' }],
+      variants = [{ id: 'basic', fix_prompt: 'variants/basic.md' }],
       requires = [],
       provides = ['test-functionality'],
     } = options;
@@ -161,8 +161,10 @@ describe('Recipes Command Integration Tests', () => {
     mockReadFileSync.mockImplementation((filePath: string) => {
       if (filePath.includes('prompt.md')) {
         return '## Goal\nTest goal\n\n## Investigation\nTest investigation\n\n## Expected Output\nTest output';
-      } else if (filePath.includes('fixes/basic.md')) {
+      } else if (filePath.includes('fix.md')) {
         return 'Basic fix prompt content';
+      } else if (filePath.includes('variants/basic.md')) {
+        return 'Basic variant fix prompt content';
       } else if (filePath.includes('plan') && filePath.includes('.md')) {
         return `title: "test plan"
 steps:
@@ -237,7 +239,7 @@ outputs:
           variants: [
             {
               id: 'basic',
-              fix_prompt: 'fixes/basic.md',
+              fix_prompt: 'variants/basic.md',
             },
           ],
         },
@@ -249,8 +251,10 @@ outputs:
     mockReadFileSync.mockImplementation((filePath: string) => {
       if (filePath.includes('prompt.md')) {
         return '## Goal\nTest goal\n\n## Investigation\nTest investigation\n\n## Expected Output\nTest output';
-      } else if (filePath.includes('fixes/basic.md')) {
+      } else if (filePath.includes('fix.md')) {
         return 'Basic fix prompt content';
+      } else if (filePath.includes('variants/basic.md')) {
+        return 'Basic variant fix prompt content';
       } else if (filePath.includes('metadata.yaml')) {
         return yamlStringify(recipeData);
       }
@@ -305,16 +309,22 @@ outputs:
       if (filePath === '/path/to/library/recipe2/prompt.md') {
         return true;
       }
-      if (filePath === '/path/to/library/recipe1/fixes') {
+      if (filePath === '/path/to/library/recipe1/fix.md') {
         return true;
       }
-      if (filePath === '/path/to/library/recipe2/fixes') {
+      if (filePath === '/path/to/library/recipe2/fix.md') {
         return true;
       }
-      if (filePath === '/path/to/library/recipe1/fixes/basic.md') {
+      if (filePath === '/path/to/library/recipe1/variants') {
         return true;
       }
-      if (filePath === '/path/to/library/recipe2/fixes/basic.md') {
+      if (filePath === '/path/to/library/recipe2/variants') {
+        return true;
+      }
+      if (filePath === '/path/to/library/recipe1/variants/basic.md') {
+        return true;
+      }
+      if (filePath === '/path/to/library/recipe2/variants/basic.md') {
         return true;
       }
       return false;
@@ -338,8 +348,10 @@ outputs:
     mockReadFileSync.mockImplementation((filePath: string) => {
       if (filePath.includes('prompt.md')) {
         return '## Goal\nTest goal\n\n## Investigation\nTest investigation\n\n## Expected Output\nTest output';
-      } else if (filePath.includes('fixes/basic.md')) {
+      } else if (filePath.includes('fix.md')) {
         return 'Basic fix prompt content';
+      } else if (filePath.includes('variants/basic.md')) {
+        return 'Basic variant fix prompt content';
       } else if (filePath.includes('recipe1/metadata.yaml')) {
         return yamlStringify({
           id: 'recipe1',
@@ -350,7 +362,7 @@ outputs:
             {
               id: 'javascript',
               default_variant: 'basic',
-              variants: [{ id: 'basic', fix_prompt: 'fixes/basic.md' }],
+              variants: [{ id: 'basic', fix_prompt: 'variants/basic.md' }],
             },
           ],
           provides: ['feature1'],
@@ -366,7 +378,7 @@ outputs:
             {
               id: 'python',
               default_variant: 'basic',
-              variants: [{ id: 'basic', fix_prompt: 'fixes/basic.md' }],
+              variants: [{ id: 'basic', fix_prompt: 'variants/basic.md' }],
             },
           ],
           provides: ['feature2'],
@@ -421,13 +433,23 @@ outputs:
         return true;
       }
       if (
-        filePath === '/test/home/.chorenzo/recipes/lib1/nested-recipe/fixes'
+        filePath === '/test/home/.chorenzo/recipes/lib1/nested-recipe/variants'
+      ) {
+        return true;
+      }
+      if (
+        filePath === '/test/home/.chorenzo/recipes/lib1/nested-recipe/fix.md'
+      ) {
+        return true;
+      }
+      if (
+        filePath === '/test/home/.chorenzo/recipes/lib1/nested-recipe/variants'
       ) {
         return true;
       }
       if (
         filePath ===
-        '/test/home/.chorenzo/recipes/lib1/nested-recipe/fixes/basic.md'
+        '/test/home/.chorenzo/recipes/lib1/nested-recipe/variants/basic.md'
       ) {
         return true;
       }
@@ -442,7 +464,9 @@ outputs:
               filePath === '/test/home/.chorenzo/recipes' ||
               filePath === '/test/home/.chorenzo/recipes/lib1' ||
               filePath === '/test/home/.chorenzo/recipes/lib2' ||
-              filePath === '/test/home/.chorenzo/recipes/lib1/nested-recipe'
+              filePath === '/test/home/.chorenzo/recipes/lib1/nested-recipe' ||
+              filePath ===
+                '/test/home/.chorenzo/recipes/lib1/nested-recipe/variants'
             );
           },
           isFile: () => filePath.includes('.'),
@@ -456,6 +480,10 @@ outputs:
         return ['nested-recipe'];
       } else if (dirPath === '/test/home/.chorenzo/recipes/lib2') {
         return [];
+      } else if (
+        dirPath === '/test/home/.chorenzo/recipes/lib1/nested-recipe/variants'
+      ) {
+        return ['basic.md'];
       }
       return [];
     });
@@ -463,8 +491,10 @@ outputs:
     mockReadFileSync.mockImplementation((filePath: string) => {
       if (filePath.includes('prompt.md')) {
         return '## Goal\nTest goal\n\n## Investigation\nTest investigation\n\n## Expected Output\nTest output';
-      } else if (filePath.includes('fixes/basic.md')) {
+      } else if (filePath.includes('fix.md')) {
         return 'Basic fix prompt content';
+      } else if (filePath.includes('variants/basic.md')) {
+        return 'Basic variant fix prompt content';
       } else if (filePath.includes('metadata.yaml')) {
         return yamlStringify({
           id: 'nested-recipe',
@@ -478,7 +508,7 @@ outputs:
               variants: [
                 {
                   id: 'basic',
-                  fix_prompt: 'fixes/basic.md',
+                  fix_prompt: 'variants/basic.md',
                 },
               ],
             },
@@ -536,8 +566,10 @@ outputs:
     mockReadFileSync.mockImplementation((filePath: string) => {
       if (filePath.includes('prompt.md')) {
         return '## Goal\nTest goal\n\n## Investigation\nTest investigation\n\n## Expected Output\nTest output';
-      } else if (filePath.includes('fixes/basic.md')) {
+      } else if (filePath.includes('fix.md')) {
         return 'Basic fix prompt content';
+      } else if (filePath.includes('variants/basic.md')) {
+        return 'Basic variant fix prompt content';
       } else if (filePath.includes('metadata.yaml')) {
         return yamlStringify({
           id: 'test-recipe',
@@ -551,7 +583,7 @@ outputs:
               variants: [
                 {
                   id: 'basic',
-                  fix_prompt: 'fixes/basic.md',
+                  fix_prompt: 'variants/basic.md',
                 },
               ],
             },
@@ -829,6 +861,12 @@ outputs:
         if (path.includes('apply_recipe.md')) {
           return true;
         }
+        if (path.includes('fix.md')) {
+          return true;
+        }
+        if (path.includes('variants')) {
+          return true;
+        }
         return true;
       });
 
@@ -906,6 +944,9 @@ outputs:
         if (filePath.includes('apply_recipe.md')) {
           return 'Apply the recipe {{ recipe_id }} to {{ project_path }}...';
         }
+        if (filePath.includes('fix.md')) {
+          return 'Base fix instructions for all variants.';
+        }
         return '';
       });
     };
@@ -947,6 +988,12 @@ outputs:
           return true;
         }
         if (path.includes('apply_recipe.md')) {
+          return true;
+        }
+        if (path.includes('fix.md')) {
+          return true;
+        }
+        if (path.includes('variants')) {
           return true;
         }
         return true;
@@ -1000,6 +1047,9 @@ outputs:
         }
         if (filePath.includes('apply_recipe.md')) {
           return 'Apply the recipe {{ recipe_id }} to {{ project_path }}...';
+        }
+        if (filePath.includes('fix.md')) {
+          return 'Base fix instructions for all variants.';
         }
         return '';
       });
@@ -1094,6 +1144,12 @@ outputs:
         if (path.includes('apply_recipe.md')) {
           return true;
         }
+        if (path.includes('fix.md')) {
+          return true;
+        }
+        if (path.includes('variants')) {
+          return true;
+        }
         return true;
       });
 
@@ -1113,6 +1169,12 @@ outputs:
         }
         if (filePath.includes('apply_recipe.md')) {
           return 'Apply the recipe {{ recipe_id }} to {{ project_path }}...';
+        }
+        if (filePath.includes('fix.md')) {
+          return 'Basic fix prompt content';
+        }
+        if (filePath.includes('variants/basic.md')) {
+          return 'Basic variant fix content';
         }
         if (filePath.includes('state.json')) {
           return '{"last_checked": "1970-01-01T00:00:00Z"}';
@@ -1166,6 +1228,12 @@ outputs:
           return true;
         }
         if (path.includes('apply_recipe.md')) {
+          return true;
+        }
+        if (path.includes('fix.md')) {
+          return true;
+        }
+        if (path.includes('variants')) {
           return true;
         }
         return true;
@@ -1277,6 +1345,12 @@ outputs:
         if (filePath.includes('apply_recipe.md')) {
           return 'Apply the recipe {{ recipe_id }} to {{ project_path }}...';
         }
+        if (filePath.includes('fix.md')) {
+          return 'Basic fix prompt content';
+        }
+        if (filePath.includes('variants/basic.md')) {
+          return 'Basic variant fix content';
+        }
         if (filePath.includes('state.json')) {
           return '{"last_checked": "1970-01-01T00:00:00Z"}';
         }
@@ -1297,8 +1371,8 @@ outputs:
 
       const mockYamlData = createMockYamlData({
         variants: [
-          { id: 'basic', fix_prompt: 'Basic fix' },
-          { id: 'advanced', fix_prompt: 'Advanced fix' },
+          { id: 'basic', fix_prompt: 'variants/basic.md' },
+          { id: 'advanced', fix_prompt: 'variants/advanced.md' },
         ],
         provides: ['test_feature.exists'],
       });
@@ -1330,8 +1404,23 @@ outputs:
         if (filePath.includes('prompt.md')) {
           return '## Goal\nTest goal\n\n## Investigation\nTest investigation\n\n## Expected Output\nTest output';
         }
+        if (filePath.includes('fix.md')) {
+          return 'Basic fix prompt content';
+        }
+        if (filePath.includes('variants/basic.md')) {
+          return 'Basic variant fix content';
+        }
+        if (filePath.includes('variants/advanced.md')) {
+          return 'Advanced variant fix content';
+        }
         if (filePath.includes('apply_recipe.md')) {
           return 'Apply the recipe {{ recipe_id }} to {{ project_path }}...';
+        }
+        if (filePath.includes('fix.md')) {
+          return 'Basic fix prompt content';
+        }
+        if (filePath.includes('variants/basic.md')) {
+          return 'Basic variant fix content';
         }
         if (filePath.includes('state.json')) {
           return '{"last_checked": "1970-01-01T00:00:00Z"}';
@@ -1369,6 +1458,12 @@ outputs:
           return true;
         }
         if (path.includes('apply_recipe.md')) {
+          return true;
+        }
+        if (path.includes('fix.md')) {
+          return true;
+        }
+        if (path.includes('variants')) {
           return true;
         }
         return true;
@@ -1431,6 +1526,12 @@ outputs:
         if (filePath.includes('apply_recipe.md')) {
           return 'Apply the recipe {{ recipe_id }} to {{ project_path }}...';
         }
+        if (filePath.includes('fix.md')) {
+          return 'Basic fix prompt content';
+        }
+        if (filePath.includes('variants/basic.md')) {
+          return 'Basic variant fix content';
+        }
         if (filePath.includes('state.json')) {
           return '{"last_checked": "1970-01-01T00:00:00Z"}';
         }
@@ -1477,6 +1578,12 @@ outputs:
           return true;
         }
         if (path.includes('apply_recipe.md')) {
+          return true;
+        }
+        if (path.includes('fix.md')) {
+          return true;
+        }
+        if (path.includes('variants')) {
           return true;
         }
         return true;
@@ -1539,6 +1646,12 @@ outputs:
         if (filePath.includes('apply_recipe.md')) {
           return 'Apply the recipe {{ recipe_id }} to {{ project_path }}...';
         }
+        if (filePath.includes('fix.md')) {
+          return 'Basic fix prompt content';
+        }
+        if (filePath.includes('variants/basic.md')) {
+          return 'Basic variant fix content';
+        }
         if (filePath.includes('state.json')) {
           return '{"last_checked": "1970-01-01T00:00:00Z"}';
         }
@@ -1594,6 +1707,12 @@ outputs:
           return true;
         }
         if (path.includes('apply_recipe.md')) {
+          return true;
+        }
+        if (path.includes('fix.md')) {
+          return true;
+        }
+        if (path.includes('variants')) {
           return true;
         }
         return true;
@@ -1726,6 +1845,12 @@ outputs:
         if (path.includes('apply_recipe.md')) {
           return true;
         }
+        if (path.includes('fix.md')) {
+          return true;
+        }
+        if (path.includes('variants')) {
+          return true;
+        }
         return true;
       });
 
@@ -1778,6 +1903,12 @@ outputs:
         if (filePath.includes('apply_recipe.md')) {
           return 'Apply the recipe {{ recipe_id }} to {{ project_path }}...';
         }
+        if (filePath.includes('fix.md')) {
+          return 'Basic fix prompt content';
+        }
+        if (filePath.includes('variants/basic.md')) {
+          return 'Basic variant fix content';
+        }
         if (filePath.includes('state.json')) {
           return '{"last_checked": "1970-01-01T00:00:00Z"}';
         }
@@ -1812,6 +1943,12 @@ outputs:
           return true;
         }
         if (path.includes('apply_recipe.md')) {
+          return true;
+        }
+        if (path.includes('fix.md')) {
+          return true;
+        }
+        if (path.includes('variants')) {
           return true;
         }
         return true;
@@ -1851,6 +1988,12 @@ outputs:
         }
         if (filePath.includes('apply_recipe.md')) {
           return 'Apply the recipe {{ recipe_id }} to {{ project_path }}...';
+        }
+        if (filePath.includes('fix.md')) {
+          return 'Basic fix prompt content';
+        }
+        if (filePath.includes('variants/basic.md')) {
+          return 'Basic variant fix content';
         }
         if (filePath.includes('state.json')) {
           return '{"last_checked": "1970-01-01T00:00:00Z"}';
@@ -1916,6 +2059,12 @@ outputs:
         if (path.includes('apply_recipe.md')) {
           return true;
         }
+        if (path.includes('fix.md')) {
+          return true;
+        }
+        if (path.includes('variants')) {
+          return true;
+        }
         return true;
       });
 
@@ -1950,6 +2099,12 @@ outputs:
         }
         if (filePath.includes('apply_recipe.md')) {
           return 'Apply the recipe {{ recipe_id }} to {{ project_path }}...';
+        }
+        if (filePath.includes('fix.md')) {
+          return 'Basic fix prompt content';
+        }
+        if (filePath.includes('variants/basic.md')) {
+          return 'Basic variant fix content';
         }
         if (filePath.includes('state.json')) {
           return '{"last_checked": "1970-01-01T00:00:00Z"}';
@@ -1997,6 +2152,12 @@ outputs:
           return true;
         }
         if (path.includes('apply_recipe.md')) {
+          return true;
+        }
+        if (path.includes('fix.md')) {
+          return true;
+        }
+        if (path.includes('variants')) {
           return true;
         }
         return true;
@@ -2050,6 +2211,12 @@ outputs:
         }
         if (filePath.includes('apply_recipe.md')) {
           return 'Apply the recipe {{ recipe_id }} to {{ project_path }}...';
+        }
+        if (filePath.includes('fix.md')) {
+          return 'Basic fix prompt content';
+        }
+        if (filePath.includes('variants/basic.md')) {
+          return 'Basic variant fix content';
         }
         if (filePath.includes('state.json')) {
           return '{"last_checked": "1970-01-01T00:00:00Z"}';
@@ -2100,6 +2267,12 @@ outputs:
         if (path.includes('apply_recipe.md')) {
           return true;
         }
+        if (path.includes('fix.md')) {
+          return true;
+        }
+        if (path.includes('variants')) {
+          return true;
+        }
         return true;
       });
 
@@ -2152,6 +2325,12 @@ outputs:
         if (filePath.includes('apply_recipe.md')) {
           return 'Apply the recipe {{ recipe_id }} to {{ project_path }}...';
         }
+        if (filePath.includes('fix.md')) {
+          return 'Basic fix prompt content';
+        }
+        if (filePath.includes('variants/basic.md')) {
+          return 'Basic variant fix content';
+        }
         if (filePath.includes('state.json')) {
           return '{"last_checked": "1970-01-01T00:00:00Z"}';
         }
@@ -2193,6 +2372,12 @@ outputs:
           return true;
         }
         if (path.includes('apply_recipe.md')) {
+          return true;
+        }
+        if (path.includes('fix.md')) {
+          return true;
+        }
+        if (path.includes('variants')) {
           return true;
         }
         return true;
@@ -2293,6 +2478,12 @@ outputs:
         if (path.includes('apply_recipe.md')) {
           return true;
         }
+        if (path.includes('fix.md')) {
+          return true;
+        }
+        if (path.includes('variants')) {
+          return true;
+        }
         return true;
       });
 
@@ -2344,6 +2535,12 @@ outputs:
         }
         if (filePath.includes('apply_recipe.md')) {
           return 'Apply the recipe {{ recipe_id }} to {{ project_path }}...';
+        }
+        if (filePath.includes('fix.md')) {
+          return 'Basic fix prompt content';
+        }
+        if (filePath.includes('variants/basic.md')) {
+          return 'Basic variant fix content';
         }
         if (filePath.includes('state.json')) {
           return '{"last_checked": "1970-01-01T00:00:00Z"}';
@@ -2392,6 +2589,12 @@ outputs:
         if (path.includes('apply_recipe.md')) {
           return true;
         }
+        if (path.includes('fix.md')) {
+          return true;
+        }
+        if (path.includes('variants')) {
+          return true;
+        }
         return true;
       });
 
@@ -2443,6 +2646,12 @@ outputs:
         }
         if (filePath.includes('apply_recipe.md')) {
           return 'Apply the recipe {{ recipe_id }} to {{ project_path }}...';
+        }
+        if (filePath.includes('fix.md')) {
+          return 'Basic fix prompt content';
+        }
+        if (filePath.includes('variants/basic.md')) {
+          return 'Basic variant fix content';
         }
         if (filePath.includes('state.json')) {
           return '{"last_checked": "1970-01-01T00:00:00Z"}';
@@ -2573,6 +2782,12 @@ outputs:
         if (path.includes('apply_recipe.md')) {
           return true;
         }
+        if (path.includes('fix.md')) {
+          return true;
+        }
+        if (path.includes('variants')) {
+          return true;
+        }
         return true;
       });
 
@@ -2633,6 +2848,9 @@ outputs:
         if (filePath.includes('apply_recipe.md')) {
           return 'Apply the recipe {{ recipe_id }} to {{ project_path }}...';
         }
+        if (filePath.includes('fix.md')) {
+          return 'Base fix instructions for all variants.';
+        }
         return '';
       });
 
@@ -2676,6 +2894,12 @@ outputs:
           return true;
         }
         if (path.includes('apply_recipe.md')) {
+          return true;
+        }
+        if (path.includes('fix.md')) {
+          return true;
+        }
+        if (path.includes('variants')) {
           return true;
         }
         return true;
@@ -2737,6 +2961,9 @@ outputs:
         }
         if (filePath.includes('apply_recipe.md')) {
           return 'Apply the recipe {{ recipe_id }} to {{ project_path }}...';
+        }
+        if (filePath.includes('fix.md')) {
+          return 'Base fix instructions for all variants.';
         }
         return '';
       });
@@ -2910,6 +3137,21 @@ outputs:
           if (filePath.includes('prompt.md')) {
             return '## Goal\nAdd formatter\n\n## Investigation\nCheck formatter\n\n## Expected Output\nFormatter configured';
           }
+          if (filePath.includes('fix.md')) {
+            return 'Basic fix prompt content';
+          }
+          if (filePath.includes('variants/basic.md')) {
+            return 'Basic variant fix content';
+          }
+          if (filePath.includes('variants/black.md')) {
+            return 'Black formatter fix content';
+          }
+          if (filePath.includes('variants/prettier.md')) {
+            return 'Prettier formatter fix content';
+          }
+          if (filePath.includes('variants/gofmt.md')) {
+            return 'Gofmt formatter fix content';
+          }
           if (
             filePath.includes(
               'apply_recipe_workspace_application_instructions.md'
@@ -2991,7 +3233,7 @@ outputs:
           {
             id: 'python',
             default_variant: 'black',
-            variants: [{ id: 'black', fix_prompt: 'fixes/black.md' }],
+            variants: [{ id: 'black', fix_prompt: 'variants/black.md' }],
           },
         ];
 
@@ -3044,12 +3286,12 @@ outputs:
           {
             id: 'javascript',
             default_variant: 'prettier',
-            variants: [{ id: 'prettier', fix_prompt: 'fixes/prettier.md' }],
+            variants: [{ id: 'prettier', fix_prompt: 'variants/prettier.md' }],
           },
           {
             id: 'python',
             default_variant: 'black',
-            variants: [{ id: 'black', fix_prompt: 'fixes/black.md' }],
+            variants: [{ id: 'black', fix_prompt: 'variants/black.md' }],
           },
         ];
 
@@ -3115,7 +3357,7 @@ outputs:
           {
             id: 'go',
             default_variant: 'gofmt',
-            variants: [{ id: 'gofmt', fix_prompt: 'fixes/gofmt.md' }],
+            variants: [{ id: 'gofmt', fix_prompt: 'variants/gofmt.md' }],
           },
         ];
 
@@ -3160,42 +3402,23 @@ outputs:
           ref: 'main',
         };
 
-        mockReadFileSync.mockImplementation((filePath: string) => {
-          if (filePath.includes('analysis.json')) {
-            return JSON.stringify({
-              isMonorepo: false,
-              hasWorkspacePackageManager: true,
-              workspaceEcosystem: 'javascript',
-              projects: [
-                {
-                  path: '/workspace/app',
-                  language: 'javascript',
-                  ecosystem: 'javascript',
-                  type: 'application',
-                  dependencies: [],
-                  hasPackageManager: true,
-                },
-              ],
-            });
-          }
-          if (filePath.includes('config.yaml')) {
-            return yamlStringify(mockYamlData.config);
-          }
-          if (filePath.includes('metadata.yaml')) {
-            return yamlStringify(mockYamlData.metadata);
-          }
-          if (filePath.includes('prompt.md')) {
-            return '## Goal\nAdd project feature\n\n## Investigation\nCheck project\n\n## Expected Output\nProject configured';
-          }
-          if (
-            filePath.includes(
-              'apply_recipe_project_application_instructions.md'
-            )
-          ) {
-            return 'Apply {{ recipe_id }} to {{ project_path }}...';
-          }
-          return '';
-        });
+        const analysisData = {
+          isMonorepo: false,
+          hasWorkspacePackageManager: true,
+          workspaceEcosystem: 'javascript',
+          projects: [
+            {
+              path: '/workspace/app',
+              language: 'javascript',
+              ecosystem: 'javascript',
+              type: 'application',
+              dependencies: [],
+              hasPackageManager: true,
+            },
+          ],
+        };
+
+        setupHierarchicalLevelReadFileSync(mockYamlData, analysisData);
 
         const result = await performRecipesApply({
           recipe: 'project-only-recipe',
@@ -3222,42 +3445,23 @@ outputs:
           ref: 'main',
         };
 
-        mockReadFileSync.mockImplementation((filePath: string) => {
-          if (filePath.includes('analysis.json')) {
-            return JSON.stringify({
-              isMonorepo: false,
-              hasWorkspacePackageManager: true,
-              workspaceEcosystem: 'javascript',
-              projects: [
-                {
-                  path: '/workspace/app',
-                  language: 'javascript',
-                  ecosystem: 'javascript',
-                  type: 'application',
-                  dependencies: [],
-                  hasPackageManager: true,
-                },
-              ],
-            });
-          }
-          if (filePath.includes('config.yaml')) {
-            return yamlStringify(mockYamlData.config);
-          }
-          if (filePath.includes('metadata.yaml')) {
-            return yamlStringify(mockYamlData.metadata);
-          }
-          if (filePath.includes('prompt.md')) {
-            return '## Goal\nAdd workspace feature\n\n## Investigation\nCheck workspace\n\n## Expected Output\nWorkspace configured';
-          }
-          if (
-            filePath.includes(
-              'apply_recipe_workspace_application_instructions.md'
-            )
-          ) {
-            return 'Apply {{ recipe_id }} at workspace level...';
-          }
-          return '';
-        });
+        const analysisData = {
+          isMonorepo: false,
+          hasWorkspacePackageManager: true,
+          workspaceEcosystem: 'javascript',
+          projects: [
+            {
+              path: '/workspace/app',
+              language: 'javascript',
+              ecosystem: 'javascript',
+              type: 'application',
+              dependencies: [],
+              hasPackageManager: true,
+            },
+          ],
+        };
+
+        setupHierarchicalLevelReadFileSync(mockYamlData, analysisData);
 
         const result = await performRecipesApply({
           recipe: 'workspace-only-recipe',
@@ -3283,7 +3487,7 @@ outputs:
           {
             id: 'python',
             default_variant: 'basic',
-            variants: [{ id: 'basic', fix_prompt: 'fixes/basic.md' }],
+            variants: [{ id: 'basic', fix_prompt: 'variants/basic.md' }],
           },
         ];
         (mockYamlData.config.libraries as Record<string, unknown>)[
@@ -3370,7 +3574,7 @@ outputs:
           {
             id: 'javascript',
             default_variant: 'basic',
-            variants: [{ id: 'basic', fix_prompt: 'fixes/basic.md' }],
+            variants: [{ id: 'basic', fix_prompt: 'variants/basic.md' }],
           },
         ];
         (mockYamlData.config.libraries as Record<string, unknown>)[
@@ -3457,7 +3661,7 @@ outputs:
           {
             id: 'javascript',
             default_variant: 'basic',
-            variants: [{ id: 'basic', fix_prompt: 'fixes/basic.md' }],
+            variants: [{ id: 'basic', fix_prompt: 'variants/basic.md' }],
           },
         ];
         (mockYamlData.config.libraries as Record<string, unknown>)[
@@ -3546,7 +3750,7 @@ outputs:
           {
             id: 'javascript',
             default_variant: 'basic',
-            variants: [{ id: 'basic', fix_prompt: 'fixes/basic.md' }],
+            variants: [{ id: 'basic', fix_prompt: 'variants/basic.md' }],
           },
         ];
         (mockYamlData.config.libraries as Record<string, unknown>)[
@@ -3683,19 +3887,9 @@ requires: []
 
         const options = { target: '/path/to/agnostic-recipe' };
 
-        const result = await performRecipesValidate(options);
-
-        expect(result.context.target).toBe('/path/to/agnostic-recipe');
-        expect(result.messages).toBeDefined();
-        expect(
-          result.messages.some(
-            (msg) =>
-              msg.type === 'error' &&
-              msg.text.includes(
-                'Missing fix.md file for ecosystem-agnostic recipe'
-              )
-          )
-        ).toBe(true);
+        await expect(performRecipesValidate(options)).rejects.toThrow(
+          'Missing required fix.md file'
+        );
       });
     });
   });
@@ -3756,10 +3950,10 @@ requires: []
         { recursive: true }
       );
       expect(mockMkdirSync).toHaveBeenCalledWith(
-        expect.stringContaining('fixes'),
+        expect.stringContaining('variants'),
         { recursive: true }
       );
-      expect(mockWriteFileSync).toHaveBeenCalledTimes(3);
+      expect(mockWriteFileSync).toHaveBeenCalledTimes(4);
     });
 
     it('should validate recipe name and convert spaces to dashes', async () => {
@@ -3941,7 +4135,11 @@ requires: []
         expect.stringContaining('Test summary')
       );
       expect(mockWriteFileSync).toHaveBeenCalledWith(
-        expect.stringContaining('javascript_default.md'),
+        expect.stringContaining('fix.md'),
+        expect.stringContaining('render-test')
+      );
+      expect(mockWriteFileSync).toHaveBeenCalledWith(
+        expect.stringContaining('variants/javascript_default.md'),
         expect.stringContaining('render-test')
       );
     });
@@ -4012,7 +4210,7 @@ requires: []
         { recursive: true }
       );
       expect(mockMkdirSync).toHaveBeenCalledWith(
-        expect.stringContaining('structure-test/fixes'),
+        expect.stringContaining('structure-test/variants'),
         { recursive: true }
       );
     });
@@ -4459,8 +4657,8 @@ requires: []
           expect.stringContaining('agnostic-recipe'),
           { recursive: true }
         );
-        expect(mockMkdirSync).not.toHaveBeenCalledWith(
-          expect.stringContaining('fixes'),
+        expect(mockMkdirSync).toHaveBeenCalledWith(
+          expect.stringContaining('variants'),
           { recursive: true }
         );
 
@@ -4469,7 +4667,7 @@ requires: []
           expect.any(String)
         );
         expect(mockWriteFileSync).not.toHaveBeenCalledWith(
-          expect.stringContaining('fixes/javascript_default.md'),
+          expect.stringContaining('variants/javascript_default.md'),
           expect.any(String)
         );
       });
@@ -4489,16 +4687,16 @@ requires: []
         expect(result.recipeName).toBe('regular-recipe');
 
         expect(mockMkdirSync).toHaveBeenCalledWith(
-          expect.stringContaining('fixes'),
+          expect.stringContaining('variants'),
           { recursive: true }
         );
 
         expect(mockWriteFileSync).toHaveBeenCalledWith(
-          expect.stringContaining('fixes/javascript_default.md'),
+          expect.stringContaining('fix.md'),
           expect.any(String)
         );
-        expect(mockWriteFileSync).not.toHaveBeenCalledWith(
-          expect.stringContaining('fix.md'),
+        expect(mockWriteFileSync).toHaveBeenCalledWith(
+          expect.stringContaining('variants/javascript_default.md'),
           expect.any(String)
         );
       });
@@ -4560,16 +4758,16 @@ requires: []
         expect(result.recipeName).toBe('specific-recipe');
 
         expect(mockMkdirSync).toHaveBeenCalledWith(
-          expect.stringContaining('fixes'),
+          expect.stringContaining('variants'),
           { recursive: true }
         );
 
         expect(mockWriteFileSync).toHaveBeenCalledWith(
-          expect.stringContaining('fixes/javascript_default.md'),
+          expect.stringContaining('fix.md'),
           expect.any(String)
         );
-        expect(mockWriteFileSync).not.toHaveBeenCalledWith(
-          expect.stringContaining('fix.md'),
+        expect(mockWriteFileSync).toHaveBeenCalledWith(
+          expect.stringContaining('variants/javascript_default.md'),
           expect.any(String)
         );
       });
@@ -4587,8 +4785,8 @@ requires: []
 
         expect(result.success).toBe(true);
 
-        expect(mockMkdirSync).not.toHaveBeenCalledWith(
-          expect.stringContaining('fixes'),
+        expect(mockMkdirSync).toHaveBeenCalledWith(
+          expect.stringContaining('variants'),
           { recursive: true }
         );
 

--- a/src/components/RecipeInfoCollection.tsx
+++ b/src/components/RecipeInfoCollection.tsx
@@ -117,7 +117,7 @@ export const RecipeInfoCollection: React.FC<RecipeInfoCollectionProps> = ({
 
       const nextPhase = getNextPhase(formState);
       if (nextPhase === 'complete') {
-        handleComplete();
+        setTimeout(() => handleComplete(), 0);
       } else {
         setPhase(nextPhase);
       }
@@ -351,7 +351,7 @@ export const RecipeInfoCollection: React.FC<RecipeInfoCollectionProps> = ({
 
   if (phase === 'generation-method') {
     if (!shouldUseInput) {
-      handleComplete();
+      setTimeout(() => handleComplete(), 0);
       return null;
     }
 
@@ -371,7 +371,7 @@ export const RecipeInfoCollection: React.FC<RecipeInfoCollectionProps> = ({
             if (useMagicGeneration) {
               setPhase('instructions');
             } else {
-              handleComplete();
+              setTimeout(() => handleComplete(), 0);
             }
           }}
         />
@@ -391,7 +391,7 @@ export const RecipeInfoCollection: React.FC<RecipeInfoCollectionProps> = ({
             setFormState((prev) => ({ ...prev, instructions: value }))
           }
           onSubmit={() => {
-            handleComplete();
+            setTimeout(() => handleComplete(), 0);
           }}
         />
       </Box>

--- a/src/templates/recipe/recipe_magic_generate.md.hbs
+++ b/src/templates/recipe/recipe_magic_generate.md.hbs
@@ -58,19 +58,41 @@ Follow these guidelines for creating the recipe:
 - Let developers implement the actual code
 - Prefer describing what to configure rather than showing trivial code
 
+**LEVEL SELECTION GUIDELINES:**
+
+Choose the appropriate recipe level based on the recipe's scope and intended usage:
+
+- **`workspace-only`**: Use for tools that MUST be global across the entire workspace
+  - Examples: Git hooks, workspace-wide package manager setup, global linting rules
+  - Never applies to individual projects, even in mixed-ecosystem scenarios
+  
+- **`project-only`**: Use for tools that MUST be per-project and never global
+  - Examples: Framework setup, project-specific build configurations, test setup
+  - Never applies at workspace level, always targets individual projects
+  
+- **`workspace-preferred`**: Use for tools that work best globally but can handle mixed ecosystems
+  - Examples: Code formatting that prefers workspace-wide rules but adapts to project differences
+  - Intelligently applies at workspace or project level based on ecosystem compatibility
+  
+**CRITICAL: Analyze your recipe's purpose and choose the most appropriate level. Default to `workspace-preferred` only if the tool genuinely benefits from workspace-level application but can handle project-level scenarios.**
+
 **FILE STRUCTURE:**
 
 1. Create {{ recipe_path }}/metadata.yaml with:
+   - **IMPORTANT: Choose appropriate `level` field based on guidelines above**
    - **IMPORTANT: Default to empty `provides: []` unless absolutely necessary**
    - Conservative requires lists referencing only essential dependencies
    - Separate variants for each tool/approach you identified
 2. Create {{ recipe_path }}/prompt.md with:
    - Generic investigation steps
    - Ecosystem-agnostic guidance
-3. Create {{ recipe_path }}/fixes/[ecosystem]\_[variant].md with:
-   - ONE tool/approach per fix file
+3. Create {{ recipe_path }}/fix.md with:
+   - Base instructions that work for all ecosystems
+   - Common setup and configuration steps
+4. Create {{ recipe_path }}/variants/[ecosystem]\_[variant].md or {{ recipe_path }}/variants/[variant].md with:
+   - ONE tool/approach per variant file
    - Specific implementation for that ecosystem and variant
    - Minimal, essential code examples only
-   - If multiple tools exist, create multiple fix files
+   - If multiple tools exist, create multiple variant files
 
 Use the Write tool to create each file following these principles.

--- a/src/templates/recipe/recipe_magic_generate_agnostic.md.hbs
+++ b/src/templates/recipe/recipe_magic_generate_agnostic.md.hbs
@@ -48,10 +48,29 @@ Follow these guidelines for creating the ecosystem-agnostic recipe:
 - Include only universal setup commands
 - Prefer describing universal configurations rather than showing language-specific code
 
+**LEVEL SELECTION GUIDELINES:**
+
+Choose the appropriate recipe level based on the recipe's scope and intended usage:
+
+- **`workspace-only`**: Use for universal tools that MUST be global across the entire workspace
+  - Examples: Git hooks, .editorconfig, global documentation configs, workspace-wide CI/CD setup
+  - Never applies to individual projects, works identically across all ecosystems
+  
+- **`project-only`**: Use for universal tools that MUST be per-project
+  - Examples: Project-specific documentation templates, individual project CI/CD configs
+  - Never applies at workspace level, needed separately in each project
+  
+- **`workspace-preferred`**: Use for universal tools that work best globally but might need project-specific handling
+  - Examples: Universal formatting rules that prefer workspace-wide but adapt to project differences
+  - Intelligently applies at workspace or project level based on requirements
+  
+**CRITICAL: Most ecosystem-agnostic recipes should be `workspace-only` since universal tools typically work best at the workspace level. Choose `project-only` only if the tool genuinely needs per-project configuration.**
+
 **FILE STRUCTURE:**
 
 1. Create {{ recipe_path }}/metadata.yaml with:
    - Empty ecosystems array: `ecosystems: []`
+   - **IMPORTANT: Choose appropriate `level` field based on guidelines above**
    - **IMPORTANT: Default to empty `provides: []` unless absolutely necessary**
    - Conservative requires lists referencing only essential dependencies
    - Universal recipe outputs (only if genuinely needed by other recipes)

--- a/src/templates/recipe/recipe_metadata.yaml.hbs
+++ b/src/templates/recipe/recipe_metadata.yaml.hbs
@@ -1,6 +1,7 @@
 id: {{ recipe_id }}
 category: {{ category }}
 summary: {{ summary }}
+level: {{ level }}
 
 ecosystems: []
 

--- a/src/types/recipe.ts
+++ b/src/types/recipe.ts
@@ -154,11 +154,33 @@ export class Recipe {
     return this.prompt;
   }
 
-  getAgnosticFixContent(): string | undefined {
-    if (!this.isEcosystemAgnostic()) {
-      return undefined;
-    }
+  getBaseFixContent(): string | undefined {
     return this.fixFiles.get('fix.md');
+  }
+
+  getVariantFixContent(variantName: string): string | undefined {
+    return this.fixFiles.get(`variants/${variantName}.md`);
+  }
+
+  getEcosystemVariantFixContent(
+    ecosystem: string,
+    variantName: string
+  ): string | undefined {
+    return this.fixFiles.get(`variants/${ecosystem}_${variantName}.md`);
+  }
+
+  getFixContentForVariant(ecosystem?: string, variantName?: string): string {
+    const baseContent = this.getBaseFixContent() || '';
+
+    if (!ecosystem || !variantName) {
+      return baseContent;
+    }
+
+    const variantContent =
+      this.getEcosystemVariantFixContent(ecosystem, variantName) ||
+      this.getVariantFixContent(variantName);
+
+    return variantContent ? baseContent + '\n\n' + variantContent : baseContent;
   }
 }
 


### PR DESCRIPTION
## Summary

This PR refactors the recipe structure to unify ecosystem-specific and ecosystem-agnostic recipes into a single, more maintainable structure with mandatory base `fix.md` files and optional variant-specific additions.

## Key Changes

### 🏗️ **Unified Recipe Structure**
- **All recipes** now require a mandatory `fix.md` file with base instructions
- **Optional `variants/` directory** for ecosystem-specific additions
- **Content concatenation**: `baseContent + '\n\n' + variantContent`
- **Removed old `fixes/` directory** structure (clean break)

### 🔧 **Core Implementation**
- **Type Definitions**: Added `getBaseFixContent()`, `getVariantContent()`, `getFixContentForVariant()` methods
- **Recipe Loading**: Modified `parseFixFiles()` to require `fix.md` and support `variants/` directory
- **Enhanced Validation**: Immediate failure when `fix.md` is missing, warnings for missing variants
- **Template Updates**: Fixed metadata template and enhanced magic generation templates

### 🤖 **Magic Generation Improvements**
- **Intelligent Level Selection**: Claude Code SDK now determines appropriate recipe levels (`workspace-only`, `project-only`, `workspace-preferred`)
- **Enhanced Templates**: Comprehensive level selection guidelines for AI generation
- **Conditional Template Variables**: Level field excluded during magic generation, allowing AI to choose

### 🧪 **Testing & Quality**
- **All 126 tests updated** to work with new structure
- **Fixed React component** state update timing issues in CLI
- **Comprehensive mock data** updates for new file structure
- **Pre-commit hooks passing** with linting and type checking

### 📚 **Documentation**
- **Updated README.md and docs/recipes.md** to reflect new unified structure
- **Added content concatenation examples** and variant usage patterns
- **Fixed all references** from `fixes/` to `variants/` directory

## Migration Impact

This change provides the foundation for future recipe migration and enhanced validation features.

## Testing

```bash
# Verify all tests pass
npm test

# Test recipe generation
npx chorenzo recipes generate test-recipe --category test --summary "Test recipe"

# Test recipe validation
npx chorenzo recipes validate test-recipe
```

## Before/After Structure

**Before** (ecosystem-specific):
```
recipe/
├── metadata.yaml
├── prompt.md
└── fixes/
    ├── javascript_eslint.md
    └── python_ruff.md
```

**After** (unified):
```
recipe/
├── metadata.yaml
├── prompt.md
├── fix.md              # Base instructions
└── variants/           # Optional additions
    ├── javascript_eslint.md
    └── python_ruff.md
```