### PR TITLE
fix: improve recipe reapplication user experience

### DIFF
--- a/src/containers/RecipesApplyContainer.tsx
+++ b/src/containers/RecipesApplyContainer.tsx
@@ -42,11 +42,7 @@ export const RecipesApplyContainer: React.FC<RecipesApplyContainerProps> = ({
 
   if (userCancelled) {
     return (
-      <ProcessDisplay
-        title="Recipe application cancelled"
-        status="error"
-        error="User cancelled re-application of recipe"
-      />
+      <ProcessDisplay title="Recipe application cancelled" status="completed" />
     );
   }
 
@@ -106,7 +102,14 @@ export const RecipesApplyContainer: React.FC<RecipesApplyContainerProps> = ({
               recipeId={reApplicationData.recipeId}
               targets={reApplicationData.reApplicationCheck.targets}
               onYes={async () => {
-                context.setResult(reApplicationData);
+                const updatedData = {
+                  ...reApplicationData,
+                  reApplicationCheck: {
+                    ...reApplicationData.reApplicationCheck,
+                    userConfirmedProceed: true,
+                  },
+                };
+                context.setResult(updatedData);
                 context.complete();
                 setShowPrompt(false);
               }}
@@ -130,8 +133,18 @@ export const RecipesApplyContainer: React.FC<RecipesApplyContainerProps> = ({
             let lastActivity = '';
 
             try {
+              const checkResult = context.getResult<{
+                recipeId: string;
+                reApplicationCheck: ReApplicationCheckResult;
+              }>('reapplication-check');
+
+              const applyOptions = checkResult?.reApplicationCheck
+                .userConfirmedProceed
+                ? { ...options, yes: true }
+                : options;
+
               const result = await performRecipesApply(
-                options,
+                applyOptions,
                 (step, isThinking) => {
                   if (step) {
                     lastActivity = step;


### PR DESCRIPTION
## Summary

Fixes issues with recipe reapplication user experience where:
- User cancellation was shown as an error instead of normal completion
- Choosing "Yes" to proceed with reapplication still showed cancellation error

## Changes

- **Fix cancellation UX**: Change status from `error` to `completed` when user cancels reapplication for better visual feedback
- **Fix "Yes" flow**: Properly pass `userConfirmedProceed` flag to the apply step so choosing "Yes" actually proceeds with reapplication
- **Improve data flow**: Extract reapplication check result and pass `yes: true` option to `performRecipesApply` when user confirms

## Test plan

- [x] Apply a recipe that hasn't been applied before - should work normally
- [x] Apply a recipe that has already been applied:
  - [x] Choose "No" - should show green checkmark with "Recipe application cancelled" 
  - [x] Choose "Yes" - should proceed with reapplication instead of showing error
- [x] Pass TypeScript checks and linting