### PR TITLE
ci: include package-lock.json in semantic-release commits

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -21,7 +21,7 @@
     [
       "@semantic-release/git",
       {
-        "assets": ["package.json"],
+        "assets": ["package.json", "package-lock.json"],
         "message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
       }
     ]


### PR DESCRIPTION
## Summary
- Updated semantic-release configuration to include package-lock.json in version bump commits
- Previously only package.json was being committed, causing lockfile to become outdated

## Test plan
- [ ] Verify the change in .releaserc.json includes both package.json and package-lock.json in assets array
- [ ] Test that future releases will commit both files during version bumps