### PR TITLE
remove: Remove all --no-progress support from CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,11 +37,8 @@ npx chorenzo init --cost
 Analyze your workspace and get detailed insights about project structure, dependencies, and ecosystems:
 
 ```bash
-# With progress UI (default)
+# Analyze workspace
 npx chorenzo analyze
-
-# Disable progress UI for simple text output
-npx chorenzo analyze --no-progress
 
 # Show detailed debug output
 npx chorenzo analyze --debug
@@ -69,9 +66,6 @@ npx chorenzo recipes validate ~/.chorenzo/recipes/core
 # Validate recipes from a git repository
 npx chorenzo recipes validate https://github.com/chorenzo-dev/recipes-core.git
 
-# Disable progress UI for simple text output
-npx chorenzo recipes validate code-formatting --no-progress
-
 # Show detailed debug output
 npx chorenzo recipes validate code-formatting --debug
 ```
@@ -86,9 +80,6 @@ npx chorenzo recipes show code-formatting
 
 # Show details for any available recipe
 npx chorenzo recipes show testing-setup
-
-# Disable progress UI for simple text output
-npx chorenzo recipes show linting --no-progress
 
 # Show detailed debug output
 npx chorenzo recipes show ci-cd --debug
@@ -113,9 +104,6 @@ npx chorenzo recipes apply testing --project frontend
 
 # Skip interactive confirmations
 npx chorenzo recipes apply eslint-config -y
-
-# Disable progress UI for simple text output
-npx chorenzo recipes apply ci-cd --no-progress
 
 # Show detailed debug output
 npx chorenzo recipes apply linting --debug
@@ -149,9 +137,6 @@ npx chorenzo recipes generate testing \
   --category development \
   --summary "Configure Jest testing framework with coverage reporting and TypeScript integration"
 
-# Disable progress UI for simple text output
-npx chorenzo recipes generate my-recipe --no-progress
-
 # Show detailed debug output
 npx chorenzo recipes generate my-recipe --debug
 
@@ -182,7 +167,6 @@ npx chorenzo recipes generate api-endpoints --magic-generate \
 
 **Options:**
 
-- `--no-progress`: Disable progress UI for simple text output
 - `--debug`: Show detailed debug output with all progress messages
 - `--cost`: Show LLM cost information (for AI-generated recipes)
 - `--location <path>`: Custom save location (supports ~ for home directory)
@@ -235,7 +219,6 @@ See our [recipes documentation](docs/recipes.md) for detailed information about 
 
 Most commands support these common flags:
 
-- `--no-progress`: Disable progress UI for simple text output
 - `--debug`: Show detailed debug output with all progress messages
 - `--cost`: Show LLM cost information (for commands that use AI)
 

--- a/src/Shell.tsx
+++ b/src/Shell.tsx
@@ -50,7 +50,6 @@ export const Shell: React.FC<ShellProps> = ({ command, options }) => {
     return (
       <AnalyzeContainer
         options={{
-          progress: options.progress,
           debug: options.debug,
           cost: options.cost,
         }}
@@ -68,7 +67,6 @@ export const Shell: React.FC<ShellProps> = ({ command, options }) => {
           reset: options.reset,
           noAnalyze: options.noAnalyze,
           yes: options.yes,
-          progress: options.progress,
           debug: options.debug,
           cost: options.cost,
         }}
@@ -91,7 +89,6 @@ export const Shell: React.FC<ShellProps> = ({ command, options }) => {
       <RecipesValidateContainer
         options={{
           target: options.target,
-          progress: options.progress,
           debug: options.debug,
         }}
         onError={(error) => {
@@ -119,7 +116,6 @@ export const Shell: React.FC<ShellProps> = ({ command, options }) => {
           variant: options.variant,
           project: options.project,
           yes: options.yes,
-          progress: options.progress,
           debug: options.debug,
           cost: options.cost,
         }}
@@ -139,7 +135,6 @@ export const Shell: React.FC<ShellProps> = ({ command, options }) => {
       <RecipesGenerateContainer
         options={{
           name: options.name,
-          progress: options.progress,
           debug: options.debug,
           cost: options.cost,
           saveLocation: options.saveLocation,
@@ -173,7 +168,6 @@ export const Shell: React.FC<ShellProps> = ({ command, options }) => {
       <RecipesShowContainer
         options={{
           recipeName: options.recipeName,
-          progress: options.progress,
           debug: options.debug,
         }}
         onError={(error) => {

--- a/src/Shell.tsx
+++ b/src/Shell.tsx
@@ -19,7 +19,6 @@ interface ShellProps {
     | 'recipes-generate'
     | 'recipes-show';
   options: {
-    progress?: boolean;
     reset?: boolean;
     noAnalyze?: boolean;
     yes?: boolean;

--- a/src/commands/recipes.ts
+++ b/src/commands/recipes.ts
@@ -292,15 +292,11 @@ export type ValidationCallback = (
   message: string
 ) => void;
 
-export interface RecipesOptions {
-  progress?: boolean;
-}
-
-export interface ValidateOptions extends RecipesOptions {
+export interface ValidateOptions extends Record<string, unknown> {
   target: string;
 }
 
-export interface RecipesGenerateOptions extends RecipesOptions {
+export interface RecipesGenerateOptions {
   name?: string;
   cost?: boolean;
   magicGenerate?: boolean;
@@ -473,7 +469,7 @@ async function findRecipeByName(recipeName: string): Promise<string[]> {
 
 async function validateRecipeByName(
   recipeName: string,
-  options: RecipesOptions,
+  options: Record<string, unknown>,
   context: Omit<ValidationContext, 'recipesValidated'>,
   onProgress?: ProgressCallback,
   onValidation?: ValidationCallback
@@ -516,7 +512,7 @@ async function validateRecipeByName(
 
 async function validateRecipeFolder(
   recipePath: string,
-  _options: RecipesOptions,
+  _options: Record<string, unknown>,
   context: Omit<ValidationContext, 'recipesValidated'>,
   onProgress?: ProgressCallback,
   onValidation?: ValidationCallback
@@ -626,7 +622,7 @@ async function validateRecipeFolder(
 
 async function validateLibrary(
   libraryPath: string,
-  _options: RecipesOptions,
+  _options: Record<string, unknown>,
   context: Omit<ValidationContext, 'recipesValidated'>,
   onProgress?: ProgressCallback,
   onValidation?: ValidationCallback
@@ -732,7 +728,7 @@ async function validateLibrary(
 
 async function validateGitRepository(
   gitUrl: string,
-  options: RecipesOptions,
+  options: Record<string, unknown>,
   context: Omit<ValidationContext, 'recipesValidated'>,
   onProgress?: ProgressCallback,
   onValidation?: ValidationCallback

--- a/src/components/RecipeInfoCollection.tsx
+++ b/src/components/RecipeInfoCollection.tsx
@@ -32,10 +32,7 @@ export const RecipeInfoCollection: React.FC<RecipeInfoCollectionProps> = ({
     initialOptions.magicGenerate !== undefined &&
     initialOptions.ecosystemAgnostic !== undefined;
 
-  const shouldUseInput =
-    initialOptions.progress !== false &&
-    isRawModeSupported === true &&
-    !hasAllRequiredParams;
+  const shouldUseInput = isRawModeSupported === true && !hasAllRequiredParams;
 
   const [formState, setFormState] = useState({
     name: initialOptions.name || '',

--- a/src/containers/RecipesValidateContainer.tsx
+++ b/src/containers/RecipesValidateContainer.tsx
@@ -47,7 +47,6 @@ export const RecipesValidateContainer: React.FC<
               const result = await performRecipesValidate(
                 {
                   target: options.target,
-                  progress: options.progress,
                 },
                 (step, isThinking) => {
                   if (step) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -23,7 +23,6 @@ program
   .option('--no-analyze', 'Skip automatic workspace analysis')
   .option('-A', 'Alias for --no-analyze')
   .option('-y, --yes', 'Skip interactive confirmation')
-  .option('--no-progress', 'Disable progress UI')
   .option('--debug', 'Show all progress messages in list format')
   .option('--cost', 'Show LLM cost information')
   .action(async (options) => {
@@ -52,7 +51,6 @@ program
 program
   .command('analyze')
   .description('Analyze your workspace structure and provide insights')
-  .option('--no-progress', 'Disable progress UI')
   .option('--debug', 'Show all progress messages in list format')
   .option('--cost', 'Show LLM cost information')
   .action(async (options) => {
@@ -97,7 +95,6 @@ Examples:
 recipesCommand
   .command('validate <target>')
   .description('Validate recipes by name, path, library, or git repository')
-  .option('--no-progress', 'Disable progress UI')
   .option('--debug', 'Show all progress messages in list format')
   .addHelpText(
     'after',
@@ -139,7 +136,6 @@ recipesCommand
   .option('--project <path>', 'Apply to specific project only')
   .option('-y, --yes', 'Skip interactive confirmations')
   .option('--force', 'Bypass re-application warnings (alias for --yes)')
-  .option('--no-progress', 'Disable progress UI')
   .option('--debug', 'Show all progress messages in list format')
   .option('--cost', 'Show LLM cost information')
   .addHelpText(
@@ -184,7 +180,6 @@ Examples:
 recipesCommand
   .command('show <recipe-name>')
   .description('Show detailed information about a recipe')
-  .option('--no-progress', 'Disable progress UI')
   .option('--debug', 'Show all progress messages in list format')
   .addHelpText(
     'after',
@@ -220,7 +215,6 @@ Examples:
 recipesCommand
   .command('generate [name]')
   .description('Generate a new recipe')
-  .option('--no-progress', 'Disable progress UI')
   .option('--debug', 'Show all progress messages in list format')
   .option('--cost', 'Show LLM cost information')
   .option(

--- a/src/main.ts
+++ b/src/main.ts
@@ -33,7 +33,6 @@ program
           reset: options.reset,
           noAnalyze: !options.analyze || options.A,
           yes: options.yes,
-          progress: options.progress,
           debug: options.debug,
           cost: options.cost,
         },
@@ -58,7 +57,6 @@ program
       React.createElement(Shell, {
         command: 'analyze',
         options: {
-          progress: options.progress,
           debug: options.debug,
           cost: options.cost,
         },
@@ -115,7 +113,6 @@ Examples:
         command: 'recipes-validate',
         options: {
           target,
-          progress: options.progress,
           debug: options.debug,
         },
       })
@@ -162,7 +159,6 @@ Examples:
           variant: options.variant,
           project: options.project,
           yes: options.yes || options.force,
-          progress: options.progress,
           debug: options.debug,
           cost: options.cost,
         },
@@ -198,7 +194,6 @@ Examples:
         command: 'recipes-show',
         options: {
           recipeName,
-          progress: options.progress,
           debug: options.debug,
         },
       })
@@ -271,7 +266,6 @@ Examples:
         command: 'recipes-generate',
         options: {
           name,
-          progress: options.progress,
           debug: options.debug,
           cost: options.cost,
           saveLocation: options.location,

--- a/src/types/common.ts
+++ b/src/types/common.ts
@@ -13,7 +13,6 @@ export interface OperationMetadata extends BaseMetadata {
 }
 
 export interface BaseContainerOptions extends Record<string, unknown> {
-  progress?: boolean;
   debug?: boolean;
   cost?: boolean;
 }

--- a/src/types/recipes-generate.ts
+++ b/src/types/recipes-generate.ts
@@ -7,7 +7,6 @@ export interface RecipesGenerateOptions {
   location?: string;
   saveLocation?: string;
   additionalInstructions?: string;
-  progress?: boolean;
   ecosystemAgnostic?: boolean;
 }
 


### PR DESCRIPTION
## Summary
• Remove --no-progress flag from all 6 CLI commands (init, analyze, recipes validate/apply/show/generate)
• Simplify component logic to always enable interactive input when supported
• Clean up type system by removing progress-related properties and interfaces
• Update documentation to remove all --no-progress references

## Test plan
- [x] All 149 existing tests pass
- [x] TypeScript compilation successful with no errors
- [x] ESLint passes with no warnings
- [x] Interactive input behavior verified to work consistently
- [x] All CLI commands function without --no-progress flag
- [x] Documentation updated to reflect new behavior