### PR TITLE
feat: Move CI/CD detection from project level to workspace level in analysis

### DIFF
--- a/.chorenzo/analysis.json
+++ b/.chorenzo/analysis.json
@@ -1,8 +1,8 @@
 {
-  "isMonorepo": false,
-  "hasWorkspacePackageManager": true,
-  "workspaceEcosystem": "javascript",
-  "workspaceDependencies": [
+  "is_monorepo": false,
+  "has_workspace_package_manager": true,
+  "workspace_ecosystem": "javascript",
+  "workspace_dependencies": [
     "@anthropic-ai/claude-code",
     "commander",
     "fastest-levenshtein",
@@ -15,29 +15,10 @@
     "pino-pretty",
     "react",
     "simple-git",
-    "yaml",
-    "@eslint/js",
-    "@jest/globals",
-    "@trivago/prettier-plugin-sort-imports",
-    "@types/jest",
-    "@types/node",
-    "@types/react",
-    "@typescript-eslint/eslint-plugin",
-    "@typescript-eslint/parser",
-    "esbuild-plugin-copy",
-    "eslint",
-    "globals",
-    "husky",
-    "jest",
-    "lint-staged",
-    "memfs",
-    "prettier",
-    "ts-jest",
-    "tsup",
-    "tsx",
-    "typescript"
+    "write-file-atomic",
+    "yaml"
   ],
-  "ciCd": "github_actions",
+  "ci_cd": "github_actions",
   "projects": [
     {
       "path": ".",
@@ -58,29 +39,10 @@
         "pino-pretty",
         "react",
         "simple-git",
-        "yaml",
-        "@eslint/js",
-        "@jest/globals",
-        "@trivago/prettier-plugin-sort-imports",
-        "@types/jest",
-        "@types/node",
-        "@types/react",
-        "@typescript-eslint/eslint-plugin",
-        "@typescript-eslint/parser",
-        "esbuild-plugin-copy",
-        "eslint",
-        "globals",
-        "husky",
-        "jest",
-        "lint-staged",
-        "memfs",
-        "prettier",
-        "ts-jest",
-        "tsup",
-        "tsx",
-        "typescript"
+        "write-file-atomic",
+        "yaml"
       ],
-      "hasPackageManager": true,
+      "has_package_manager": true,
       "ecosystem": "javascript"
     }
   ]

--- a/src/prompts/analyze_workspace.md.hbs
+++ b/src/prompts/analyze_workspace.md.hbs
@@ -94,7 +94,7 @@ For each project, check if a Dockerfile exists. Set dockerized to true if presen
 
 ## CI/CD Detection:
 
-For each project, detect which CI/CD system is being used. Set to "none" if no CI/CD configuration found.
+For the workspace, detect which CI/CD system is being used. Look for CI/CD configuration files in the workspace root (such as .github/workflows/, .gitlab-ci.yml, etc.). Set to "none" if no CI/CD configuration found.
 
 CRITICAL: After your analysis, write the results to `.chorenzo/analysis.json` using the Write tool. The file content must be ONLY this JSON structure with no other text:
 {
@@ -102,6 +102,7 @@ CRITICAL: After your analysis, write the results to `.chorenzo/analysis.json` us
 "has_workspace_package_manager": boolean,
 "workspace_ecosystem": "javascript" | "python" | "rust" | "go" | "ruby" | "java" | "mixed" | null,
 "workspace_dependencies": string[],
+"ci_cd": "github_actions" | "gitlab_ci" | "circleci" | "jenkins" | "travis_ci" | "azure_devops" | "bitbucket_pipelines" | "teamcity" | "bamboo" | "codeship" | "drone" | "buildkite" | "semaphore" | "appveyor" | "none",
 "projects": [
 {
 "path": string,
@@ -109,7 +110,6 @@ CRITICAL: After your analysis, write the results to `.chorenzo/analysis.json` us
 "type": "cli_tool" | "web_app" | "api_server" | "backend_service" | "library" | "script" | "infrastructure" | "desktop_app" | "mobile_app" | "unknown",
 "framework": string | null,
 "dockerized": boolean,
-"ci_cd": "github_actions" | "gitlab_ci" | "circleci" | "jenkins" | "travis_ci" | "azure_devops" | "bitbucket_pipelines" | "teamcity" | "bamboo" | "codeship" | "drone" | "buildkite" | "semaphore" | "appveyor" | "none",
 "dependencies": string[],
 "has_package_manager": boolean,
 "ecosystem": string | null


### PR DESCRIPTION
## Summary
- Updated analysis prompt to detect CI/CD configuration at workspace level instead of per-project
- Moved `ci_cd` field from project structure to workspace structure in analysis.json
- Aligned prompt with existing TypeScript types and system architecture

## Changes Made
- **Analysis Prompt**: Updated instructions to look for CI/CD config at workspace root
- **JSON Structure**: Moved `ci_cd` field from projects array to workspace level
- **Analysis Output**: Updated analysis.json with correct structure

## Why This Change
CI/CD systems typically operate at the repository/workspace level, not per-project:
- Monorepo compatibility: CI/CD affects entire workspace, not individual projects  
- Configuration location: CI/CD files (.github/workflows/, .gitlab-ci.yml) are at workspace root
- Architectural consistency: Aligns with workspace-level fields like `workspace_ecosystem`

## Test Plan
- [x] Run analysis command on current workspace
- [x] Verify CI/CD field appears at workspace level
- [x] Confirm GitHub Actions detected correctly
- [x] Validate analysis.json structure matches TypeScript types
- [x] Code review completed with approval