### PR TITLE
fix: Increase maxTurns for analysis operations from 15 to 50

### DIFF
--- a/src/commands/analyze.ts
+++ b/src/commands/analyze.ts
@@ -120,7 +120,7 @@ export async function performAnalysis(
       prompt,
       options: {
         model: 'sonnet',
-        maxTurns: 15,
+        maxTurns: 50,
         allowedTools: [
           'Read',
           'LS',


### PR DESCRIPTION
## Summary
- Increase maxTurns from 15 to 50 for analysis operations
- Prevents analysis failures due to insufficient conversation turns
- Allows Claude to fully complete complex workspace analysis
- Addresses cases where analysis was cut short before completion

## Test plan
- [ ] Verify analysis operations complete successfully on complex workspaces
- [ ] Confirm no premature termination due to turn limits
- [ ] Test analysis on large codebases that previously failed