### PR TITLE
fix: Correct Ecosystem enum to only include package registry ecosystems

### DIFF
--- a/src/types/analysis.ts
+++ b/src/types/analysis.ts
@@ -31,7 +31,6 @@ export enum CiCdSystem {
 
 export enum Ecosystem {
   Javascript = 'javascript',
-  Typescript = 'typescript',
   Python = 'python',
   Java = 'java',
   Csharp = 'csharp',
@@ -40,14 +39,13 @@ export enum Ecosystem {
   Ruby = 'ruby',
   Php = 'php',
   Swift = 'swift',
-  Kotlin = 'kotlin',
   Dart = 'dart',
   Elixir = 'elixir',
-  Scala = 'scala',
-  Clojure = 'clojure',
   Haskell = 'haskell',
-  C = 'c',
-  Cpp = 'cpp',
+  Perl = 'perl',
+  R = 'r',
+  Julia = 'julia',
+  Lua = 'lua',
   Unknown = 'unknown',
 }
 


### PR DESCRIPTION
## Summary
- Fixed ecosystem validation to properly reject invalid values like 'typescript'
- Aligned Ecosystem enum with actual package registry ecosystems

## Changes
- Removed invalid ecosystem values that don't represent distinct package registries:
  - `Typescript` (uses Javascript/npm ecosystem)
  - `Kotlin`, `Scala`, `Clojure` (use Java/Maven ecosystem)  
  - `C`, `Cpp` (no unified package ecosystem)
- Added missing modern package ecosystems:
  - `Perl` (CPAN)
  - `R` (CRAN)
  - `Julia` (General Registry)
  - `Lua` (LuaRocks)

## Test plan
- [ ] Verify that analysis validation now correctly rejects 'typescript' as an ecosystem value
- [ ] Confirm TypeScript projects should use `ecosystem: 'javascript'`
- [ ] Check that all remaining ecosystem values represent actual package registries