### PR TITLE
fix: Remove remaining typescript ecosystem references from tests and analysis

### DIFF
--- a/.chorenzo/analysis.json
+++ b/.chorenzo/analysis.json
@@ -1,7 +1,7 @@
 {
   "isMonorepo": false,
   "hasWorkspacePackageManager": true,
-  "workspaceEcosystem": "typescript",
+  "workspaceEcosystem": "javascript",
   "workspaceDependencies": [
     "@anthropic-ai/claude-code",
     "commander",
@@ -45,7 +45,7 @@
         "zod"
       ],
       "hasPackageManager": true,
-      "ecosystem": "typescript"
+      "ecosystem": "javascript"
     }
   ]
 }

--- a/src/commands/analyze.test.ts
+++ b/src/commands/analyze.test.ts
@@ -594,7 +594,7 @@ describe('Analyze Command Integration Tests', () => {
     const analysisJson = {
       isMonorepo: false,
       hasWorkspacePackageManager: true,
-      workspaceEcosystem: 'typescript',
+      workspaceEcosystem: 'javascript',
       workspaceDependencies: ['typescript', 'next'],
       ciCd: 'github_actions',
       projects: [
@@ -628,7 +628,7 @@ describe('Analyze Command Integration Tests', () => {
     expect(result.analysis).toEqual({
       isMonorepo: false,
       hasWorkspacePackageManager: true,
-      workspaceEcosystem: 'typescript',
+      workspaceEcosystem: 'javascript',
       workspaceDependencies: ['typescript', 'next'],
       ciCd: 'github_actions',
       projects: [

--- a/src/commands/recipes.validate.test.ts
+++ b/src/commands/recipes.validate.test.ts
@@ -1533,9 +1533,9 @@ requires: []
         }
         if (filePath.includes('analysis.json')) {
           return JSON.stringify({
-            workspaceEcosystem: 'typescript',
+            workspaceEcosystem: 'javascript',
             projects: [
-              { path: '../../../etc/passwd', ecosystem: 'typescript' },
+              { path: '../../../etc/passwd', ecosystem: 'javascript' },
             ],
           });
         }
@@ -1605,7 +1605,7 @@ requires: []
         }
         if (filePath.includes('analysis.json')) {
           return JSON.stringify({
-            workspaceEcosystem: 'typescript',
+            workspaceEcosystem: 'javascript',
             projects: [],
           });
         }


### PR DESCRIPTION
## Summary
- Cleaned up remaining references to 'typescript' as an ecosystem value
- Changed all instances to use 'javascript' ecosystem for TypeScript projects
- Ensures full consistency with the corrected Ecosystem enum

## Changes
- **Test files**: Updated test mocks that were using invalid `ecosystem: 'typescript'` values
- **Project analysis**: Fixed this project's own analysis.json that incorrectly used 'typescript' ecosystem  
- **Consistency**: Aligns with the fact that TypeScript projects use the JavaScript/npm ecosystem

## Test plan
- [x] All existing tests pass with the corrected ecosystem values
- [x] TypeScript compilation passes
- [x] Validation now correctly rejects 'typescript' as an ecosystem value

This complements PR #74 by ensuring no remaining references to the invalid 'typescript' ecosystem exist anywhere in the codebase.