### PR TITLE
feat: Update engine allowlist to support package manager commands for dependency management

### DIFF
--- a/src/commands/recipes.apply.test.ts
+++ b/src/commands/recipes.apply.test.ts
@@ -1540,6 +1540,31 @@ describe('Recipe Application', () => {
       expect(result.summary.successfulProjects).toBe(1);
     });
 
+    it('should include all package manager commands in allowedTools', async () => {
+      setupStandardApplyScenario();
+
+      const result = await performRecipesApply({
+        recipe: 'test-recipe',
+      });
+
+      expect(mockQuery).toHaveBeenCalledWith(
+        expect.objectContaining({
+          options: expect.objectContaining({
+            allowedTools: expect.arrayContaining([
+              'Bash(npm install)',
+              'Bash(yarn install)',
+              'Bash(pnpm install)',
+              'Bash(pip install)',
+              'Bash(pip install -e .)',
+              'Bash(poetry install)',
+              'Bash(pipenv install)',
+            ]),
+          }),
+        })
+      );
+      expect(result.summary.successfulProjects).toBe(1);
+    });
+
     it('should apply workspace-level recipe successfully', async () => {
       mockExistsSync.mockImplementation((path) => {
         if (path.includes('analysis.json')) {

--- a/src/commands/recipes.apply.ts
+++ b/src/commands/recipes.apply.ts
@@ -1013,22 +1013,27 @@ async function executeRecipe(
       },
     };
 
+    const installCommands = ['npm', 'yarn', 'pnpm', 'pip', 'poetry', 'pipenv'];
+    const allowedTools = [
+      'Bash',
+      'Read',
+      'Write',
+      'Edit',
+      'MultiEdit',
+      'LS',
+      'Glob',
+      'Grep',
+      'Bash(npx chorenzo recipes validate-state*)',
+      ...installCommands.map((command) => `Bash(${command} install)`),
+      'Bash(pip install -e .)',
+    ];
+
     const operationResult = await executeCodeChangesOperation(
       query({
         prompt: applicationPrompt,
         options: {
           model: 'sonnet',
-          allowedTools: [
-            'Bash',
-            'Read',
-            'Write',
-            'Edit',
-            'MultiEdit',
-            'LS',
-            'Glob',
-            'Grep',
-            'Bash(npx chorenzo recipes validate-state*)',
-          ],
+          allowedTools,
           disallowedTools: [
             'Bash(git commit:*)',
             'Bash(git push:*)',


### PR DESCRIPTION
## Summary

Add support for package manager install commands to the recipe engine's command allowlist. This enables recipes to update lock files after dependency changes, which is required for the "remove redundant dependencies" recipe.

## Changes

- Add simple static allowlist of package manager install commands: `npm install`, `yarn install`, `pnpm install`, `pip install`, `poetry install`, `pipenv install`
- Include `pip install -e .` variant for Python development installs
- Update integration tests to verify all package manager commands are allowed during recipe execution
- Maintain existing security boundaries with disallowed dangerous commands

## Test plan

- [x] All existing tests pass
- [x] New integration test verifies package manager commands are included in allowedTools
- [x] TypeScript compilation succeeds
- [x] Linting passes
- [x] Pre-commit hooks pass

## Security considerations

- Commands are only allowed during recipe execution context via Claude Code SDK
- Maintains existing disallowed dangerous commands (git destructive operations, sudo, rm, etc.)
- Simple static list avoids complex validation logic while providing necessary functionality

This unblocks the "remove redundant dependencies" recipe which needs to update lock files after removing dependencies.