### PR TITLE
fix: Fix handling of .applied reserved keywords in recipe validation

### DIFF
--- a/src/commands/recipes.apply.ts
+++ b/src/commands/recipes.apply.ts
@@ -433,6 +433,9 @@ function validateDependencies(
         }
 
         currentValue = getProjectCharacteristic(project, dependency.key);
+      } else {
+        const stateValue = currentState[dependency.key];
+        currentValue = stateValue ? String(stateValue) : undefined;
       }
     } else {
       const stateValue = currentState[dependency.key];


### PR DESCRIPTION
## Summary
- Fixed a bug where recipe requirements ending with `.applied` were incorrectly marked as missing
- Keys ending with `.applied` are reserved keywords but lacked proper handling in the validation logic

## Problem
When validating recipe requirements, keys ending with `.applied` (like `code-formatting.applied`) were treated as reserved keywords but had no handler in the reserved keyword processing path. This caused:
- The validation to skip checking the state for these keys
- Requirements to be marked as missing even when they existed in workspace state
- Recipes like `code-formatting-sort-imports` to fail with "unmet requirements" errors

## Solution
Added proper handling for `.applied` keys in the reserved keyword validation path by:
- Adding an else clause to check `.applied` keys against the current state
- Ensuring these keys are properly resolved when they don't match workspace or project patterns

## Test plan
- [x] Verified the fix allows `code-formatting-sort-imports` recipe to apply successfully
- [x] Confirmed the recipe correctly finds `code-formatting.applied: true` in workspace state
- [x] Pre-commit hooks pass (linting, formatting, type checking)