### PR TITLE
fix: Fix recipe review timeout issues

### DIFF
--- a/src/templates/validation/code_sample_review.md.hbs
+++ b/src/templates/validation/code_sample_review.md.hbs
@@ -43,15 +43,14 @@ These files should NOT contain:
 ❌ **Base instructions**: Common steps (belongs in fix.md)
 ❌ **Multi-line code blocks**: Any code sample longer than 1 line (explain verbally instead)
 
-## Files to Review
+## Review Process
 
-You are currently in the recipe directory `{{recipePath}}` for recipe `{{recipeName}}`. 
+You are analyzing recipe `{{recipeName}}` in directory `{{recipePath}}`.
 
-1. Use the LS tool to discover all recipe files (metadata.yaml, prompt.md, fix.md, and any files in variants/)
-2. Use the Read tool to examine each file's content
-3. **CRITICAL**: Read metadata.yaml first to identify all "provides" fields
-4. Verify that prompt.md contains Expected Output descriptions for EVERY provides field
-5. Analyze all content according to the rules above
+**Step 1**: Use LS to list all files in the recipe directory and variants subdirectory
+**Step 2**: Read metadata.yaml to identify all "provides" fields  
+**Step 3**: Read and analyze each recipe file according to the content rules
+**Step 4**: Generate the review report
 
 ## Content Violations to Identify
 
@@ -106,14 +105,13 @@ Return a markdown report with this structure:
 [Overall suggestions for improving content organization]
 ```
 
-## Analysis Guidelines
+## Instructions
 
-- Focus on content placement, not formatting or structure
-- Be specific about what content belongs where
-- **Flag any multi-line code blocks in fix.md or variant files as violations**
-- Provide actionable suggestions for fixing violations
-- Consider the recipe's purpose when evaluating content
-- Check for content duplication between fix.md and variants
-- Single-line commands are acceptable in fix.md only if universal; variant-specific commands belong in variant files
+Analyze each file's content placement according to the rules above. Focus on identifying:
+1. Implementation instructions in prompt.md (should be in fix.md)
+2. Investigation logic in fix.md or variants (should be in prompt.md)  
+3. Content duplication between fix.md and variants
+4. Multi-line code blocks in fix.md or variant files
+5. Missing Expected Output coverage for all metadata.yaml "provides" fields
 
-Please analyze the recipe files and return ONLY the markdown report.
+Return ONLY the markdown report in the specified format.

--- a/src/utils/ai-review.utils.ts
+++ b/src/utils/ai-review.utils.ts
@@ -83,7 +83,8 @@ async function reviewRecipeContent(
         prompt,
         options: {
           model: DEFAULT_AI_MODEL,
-          allowedTools: ['Read', 'LS'],
+          allowedTools: ['Read', 'LS', 'Glob', 'Grep'],
+          disallowedTools: ['TodoWrite'],
           permissionMode: 'bypassPermissions',
           cwd: recipePath,
         },


### PR DESCRIPTION
## Summary
- Fixed persistent timeout issues in recipe review system that were failing after 60+ seconds
- Added missing Glob and Grep tools for efficient file operations
- Explicitly disallowed TodoWrite to prevent task management overhead causing delays
- Streamlined review template instructions for better clarity

## Root Cause
The recipe review system was consistently timing out due to:
1. **Missing efficient file tools**: Only had Read/LS, needed Glob/Grep for complex operations
2. **TodoWrite overhead**: Claude was automatically trying to use TodoWrite for task management, causing processing conflicts since it wasn't in allowed tools
3. **Complex template**: Instructions were encouraging multi-step orchestration that increased processing time

## Changes Made
- **ai-review.utils.ts**: Added `Glob` and `Grep` to `allowedTools`, added `TodoWrite` to `disallowedTools`
- **code_sample_review.md.hbs**: Streamlined review process instructions to be more direct and efficient

## Test Results
- ✅ Recipe reviews now complete successfully in ~40 seconds instead of timing out
- ✅ Provides detailed analysis of content placement violations
- ✅ No more "Claude execution failed with error_during_execution" errors
- ✅ TodoWrite conflicts eliminated

## Test Plan
- [x] Recipe review completes without timeouts
- [x] Review provides comprehensive analysis of recipe structure violations
- [x] All file types processed correctly (metadata.yaml, prompt.md, fix.md, variants/*.md)
- [x] No TodoWrite tool conflicts in logs