### PR TITLE
fix: Enhance recipe review to detect redundant provides fields

### DIFF
--- a/src/templates/validation/code_sample_review.md.hbs
+++ b/src/templates/validation/code_sample_review.md.hbs
@@ -49,8 +49,28 @@ You are analyzing recipe `{{recipeName}}` in directory `{{recipePath}}`.
 
 **Step 1**: Use LS to list all files in the recipe directory and variants subdirectory
 **Step 2**: Read metadata.yaml to identify all "provides" fields  
-**Step 3**: Read and analyze each recipe file according to the content rules
-**Step 4**: Generate the review report
+**Step 3**: Analyze provides fields for redundancy - check if multiple fields represent the same logical state
+**Step 4**: Read and analyze each recipe file according to the content rules
+**Step 5**: Generate the review report
+
+### Provides Field Analysis
+Note: Every recipe automatically generates `<recipe-name>.applied` when executed. Additional provides fields should add meaningful state beyond this.
+
+Legitimate provides fields are those that other recipes can depend on:
+- Platform/tool choices that affect other recipes (e.g., "ci-pipeline.platform" = "github_actions")
+- Feature flags that change behavior (e.g., "auth.method" = "oauth2")
+- Discovered values other recipes need (e.g., "package-manager.type" = "npm")
+- Distinct capabilities that can exist independently (e.g., "supports_feature_x", "enables_mode_y")
+
+Check for redundancy when:
+- Multiple fields represent the same logical state
+- Fields describe implementation details rather than meaningful state for other recipes to depend on
+- The automatic `.applied` field would suffice
+
+Examples of redundant provides:
+- Having both "linter.enabled" and "linter.active" when they mean the same thing
+- Providing "tool.version" or "tool.options_list" that no other recipe would depend on
+- Sequential states like "installed", "setup", "ready" when the final state implies the others
 
 ## Content Violations to Identify
 
@@ -61,6 +81,7 @@ You are analyzing recipe `{{recipeName}}` in directory `{{recipePath}}`.
 - **Wrong File Purpose**: File contains primarily content meant for another file
 - **Multi-line Code Blocks**: Code samples longer than 1 line in fix.md or variant files
 - **Missing Provides Coverage**: prompt.md lacks Expected Output descriptions for fields listed in metadata.yaml's "provides" section
+- **Redundant Provides Fields**: Provides fields that don't add meaningful state beyond the automatic `<recipe-name>.applied` field
 
 ### Suggestions to Provide
 For each violation, suggest which file the content should be moved to and why.
@@ -113,5 +134,8 @@ Analyze each file's content placement according to the rules above. Focus on ide
 3. Content duplication between fix.md and variants
 4. Multi-line code blocks in fix.md or variant files
 5. Missing Expected Output coverage for all metadata.yaml "provides" fields
+6. **Redundant provides fields**: Critically evaluate if multiple provides fields represent the same state or if a single boolean would suffice. This is a common issue that should be flagged.
+
+**Important**: Only report violations you are confident about. Do not use uncertain language like "potentially", "may be", or "possibly". If you're not certain something is a violation, do not report it.
 
 Return ONLY the markdown report in the specified format.


### PR DESCRIPTION
## Summary
Enhances the recipe review system to detect and flag redundant provides fields that don't add meaningful value beyond the automatic `<recipe-name>.applied` field.

## Changes Made
- **Added provides field analysis step** to the review process
- **Defined criteria** for legitimate vs redundant provides fields  
- **Added examples** of when provides fields add value (platform choices, feature flags, discovered values, distinct capabilities)
- **Required decisive language** - reviewers must be confident about violations, no "potentially" or uncertain language
- **Clear guidelines** on what constitutes redundancy vs meaningful state differentiation

## Problem Solved
Previously, recipes could have multiple provides fields that essentially represent the same state (e.g., `configured: true` and `options_enabled: string` when both just indicate the recipe was applied). This creates noise in the dependency system and makes it harder for other recipes to determine what state they actually depend on.

## Examples of Redundant Provides
- Multiple boolean fields representing the same logical state
- Implementation details that no other recipe would depend on  
- Sequential states where the final state implies the others
- Fields that don't add value beyond the automatic `.applied` field

## Examples of Legitimate Provides
- Platform/tool choices that affect other recipes
- Feature flags that change behavior
- Discovered values other recipes need
- Distinct capabilities that can exist independently

## Testing
- ✅ Successfully detects redundant provides in test recipes
- ✅ Correctly identifies legitimate provides fields 
- ✅ Uses decisive language without uncertainty
- ✅ Maintains existing review functionality for other violation types